### PR TITLE
Fix - experiment ending early from corpus row count mismatch

### DIFF
--- a/task-launcher/src/tasks/matrix-reasoning/timeline.js
+++ b/task-launcher/src/tasks/matrix-reasoning/timeline.js
@@ -37,7 +37,7 @@ export default function buildMatrixTimeline(config, mediaAssets) {
         task: config.task,
       }),
     ],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [preloadTrials, initialTimeline, practiceBlock, stimulusBlock];

--- a/task-launcher/src/tasks/memory-game/timeline.js
+++ b/task-launcher/src/tasks/memory-game/timeline.js
@@ -17,7 +17,7 @@ export default function buildMemoryTimeline(config, mediaAssets) {
 
   const corsiBlock = {
     timeline: [corsiBlocksDisplay, corsiBlocks],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [

--- a/task-launcher/src/tasks/mental-rotation/timeline.js
+++ b/task-launcher/src/tasks/mental-rotation/timeline.js
@@ -43,7 +43,7 @@ export default function buildMentalRotationTimeline(config, mediaAssets) {
       }),
       ifRealTrialResponse,
     ],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [

--- a/task-launcher/src/tasks/same-different-selection/timeline.js
+++ b/task-launcher/src/tasks/same-different-selection/timeline.js
@@ -25,7 +25,7 @@ export default function buildSameDifferentTimeline(config, mediaAssets) {
 
   const stimulusBlock = {
     timeline: [setupStimulus, stimulus],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const afcBlock = {

--- a/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
+++ b/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
@@ -14,7 +14,9 @@ import { shuffleStimulusTrials } from './randomizeStimulusBlocks';
 
 export let corpora;
 
-let maxStimulusTrials = 0;
+let totalTrials = 0;
+
+// TODO: Remove (DEPRECATED)
 let maxPracticeTrials = 0;
 
 let stimulusData = [],
@@ -36,6 +38,7 @@ function containsLettersOrSlash(str) {
 const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
   let currTrialTypeBlock = ''
   let currPracticeAmount = 0
+  let totalPractice = 0
 
   csvInput.forEach((row) => {
     const newRow = {
@@ -63,12 +66,10 @@ const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
       newRow.distractors = newRow.distractors.map((choice) => camelize(choice));
     }
 
-    // if (row.notes === 'practice') {
-    //   practiceData.push(newRow);
-    //   maxPracticeTrials += 1;
-    // } else 
-    if (newRow.notes !== 'practice' && newRow.trialType !== 'instructions') {
-      maxStimulusTrials += 1;
+    totalTrials += 1;
+
+    if (row.notes === 'practice') {
+      totalPractice += 1;
     }
 
     let currentTrialType = newRow.trialType
@@ -93,6 +94,9 @@ const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
     }
 
   });
+
+  // Adjust totalTrials to account for practice trials that might not be added
+  totalTrials -= (totalPractice - numOfPracticeTrials);
 
   if (!sequentialStimulus) {
     stimulusData = shuffleStimulusTrials(stimulusData);
@@ -140,7 +144,7 @@ export const fetchAndParseCorpus = async (config) => {
 
     try {
       await parseCSVs(urls);
-      store.session.set('maxStimulusTrials', maxStimulusTrials);
+      store.session.set('totalTrials', totalTrials);
 
       if (numOfPracticeTrials > maxPracticeTrials) config.numOfPracticeTrials = maxPracticeTrials;
 

--- a/task-launcher/src/tasks/shared/helpers/getStimulusCount.js
+++ b/task-launcher/src/tasks/shared/helpers/getStimulusCount.js
@@ -23,7 +23,7 @@ function createBlocks(numOfBlocks, numOfTrials) {
 // get size of blocks
 export const getStimulusCount = (userMode) => {
   const { numberOfTrials, stimulusBlocks } = store.session.get('config');
-  const maxNumberOfTrials = store.session.get('maxStimulusTrials');
+  const maxNumberOfTrials = store.session.get('totalTrials');
 
   let countList;
 

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.js
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.js
@@ -11,7 +11,7 @@ import { camelize } from "@bdelab/roar-utils";
 import { getDevice } from "@bdelab/roar-utils";
 
 const isMobile = getDevice() === 'mobile'
-const NUM_INCORRECT_RESPONSES_TO_END = 3
+const numIncorrectResponsesToEnd = 3
 
 // Previously chosen responses for current practice trial
 let practiceResponses = []
@@ -530,6 +530,7 @@ function doOnFinish(data, task) {
             currPracticeChoiceMix = []
             currPracticeAnswerIdx = null
         } else {
+            // Only increase incorrect trials if response is incorrect not a practice trial
             if (!isPractice(stimulus.notes)) {
                 store.session.transact("incorrectTrials", (oldVal) => oldVal + 1);
             }
@@ -580,8 +581,7 @@ function doOnFinish(data, task) {
         })
     }
 
-    if(store.session.get("incorrectTrials") >= NUM_INCORRECT_RESPONSES_TO_END) {
-        store.session.set("incorrectTrials", 0);
+    if(store.session.get("incorrectTrials") >= numIncorrectResponsesToEnd) {
         jsPsych.endExperiment(
             `<div id="prompt-container-text">
                 <p id="prompt">The experiment is over. Thank you!</p>

--- a/task-launcher/src/tasks/theory-of-mind/timeline.js
+++ b/task-launcher/src/tasks/theory-of-mind/timeline.js
@@ -23,7 +23,7 @@ export default function buildTOMTimeline(config, mediaAssets) {
 
   const stimulusBlock = {
     timeline: [setupStimulus, afcStimulus(trialConfig)],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [

--- a/task-launcher/src/tasks/trog/timeline.js
+++ b/task-launcher/src/tasks/trog/timeline.js
@@ -33,7 +33,7 @@ export default function buildTROGTimeline(config, mediaAssets) {
 
   const stimulusBlock = {
     timeline: [setupStimulus, afcStimulus(trialConfig)],
-    repetitions: store.session.get('maxStimulusTrials'),
+    repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [


### PR DESCRIPTION
- Changing variable name maxStimulusTrials to totalTrials 
- Now accounts for all trials minus the amount of practice trials NOT given (Ex. 100 rows in corpus = 100 trials, maxPracticeTrials = 2, total trials will be 92).
- Always includes instructions. I assume that we will always want to give the amount of instructions listed in the corpus.