### PR TITLE
Adding styling from Figma, pulling out code, updating data saved to db

### DIFF
--- a/task-launcher/src/styles/task.scss
+++ b/task-launcher/src/styles/task.scss
@@ -630,16 +630,22 @@
 
       .jspsych-corsi-overide {
         display: grid;
-        gap: 5px; /* adjust as needed for spacing between blocks */
+        gap: 15px; /* adjust as needed for spacing between blocks */
         position: relative;
         width: 25rem;
         height: 25rem;
 
         .jspsych-corsi-block-overide {
-          background-color: #878a8c;
+          background-color: rgba(215, 215, 215, 0.93);
           width: 100%;
           height: 100%;
+          border-radius: 2rem;
+          border: 6px solid rgba(162, 162, 162, 0.93);
         }
+      }
+
+      .corsi-block-overide-prompt {
+        font-size: 2.5rem;
       }
 
       // -----------------------------------------------------------------------

--- a/task-launcher/src/tasks/memory-game/timeline.js
+++ b/task-launcher/src/tasks/memory-game/timeline.js
@@ -4,26 +4,27 @@ import { initTimeline, initTrialSaving } from '../shared/helpers';
 // setup
 import { jsPsych } from '../taskSetup';
 import { initializeCat } from '../taskSetup';
-import { createPreloadTrials } from '../shared/helpers';
 import store from 'store2';
 
 // trials
 import { exitFullscreen } from '../shared/trials';
-import { corsiBlocksDisplay, corsiBlocks } from './trials/stimulus';
+import { getCorsiBlocks } from './trials/stimulus';
 
 export default function buildMemoryTimeline(config, mediaAssets) {
   initTrialSaving(config);
   const initialTimeline = initTimeline(config);
 
-  const corsiBlock = {
-    timeline: [corsiBlocksDisplay, corsiBlocks],
+  const corsiBlocks = {
+    timeline: [
+      getCorsiBlocks({ mode: 'display' }),
+      getCorsiBlocks({ mode: 'input' }),
+    ],
     repetitions: store.session.get('totalTrials'),
   };
 
   const timeline = [
-    // preloadTrials,
     initialTimeline,
-    corsiBlock,
+    corsiBlocks,
   ];
 
   initializeCat();

--- a/task-launcher/src/tasks/memory-game/timeline.js
+++ b/task-launcher/src/tasks/memory-game/timeline.js
@@ -19,7 +19,7 @@ export default function buildMemoryTimeline(config, mediaAssets) {
       getCorsiBlocks({ mode: 'display' }),
       getCorsiBlocks({ mode: 'input' }),
     ],
-    repetitions: store.session.get('totalTrials'),
+    repetitions: 10,
   };
 
   const timeline = [

--- a/task-launcher/src/tasks/memory-game/trials/stimulus.js
+++ b/task-launcher/src/tasks/memory-game/trials/stimulus.js
@@ -2,6 +2,7 @@ import jsPsychCorsiBlocks from '@jspsych-contrib/plugin-corsi-blocks';
 import { createGrid, generateRandomSequence } from '../helpers/grid';
 import store from 'store2';
 import { jsPsych } from '../../taskSetup';
+import _isEqual from 'lodash/isEqual';
 
 const age = store.session.get('config')?.userMetadata.age;
 
@@ -15,98 +16,71 @@ const sequenceLength = age > 6 ? 4 : 2;
 const grid = createGrid(x, y, numOfblocks, blockSize, gridSize, blockSpacing);
 let generatedSequence = generateRandomSequence(numOfblocks, sequenceLength);
 
-export const corsiBlocksDisplay = {
-  type: jsPsychCorsiBlocks,
-  sequence: () => generatedSequence,
-  blocks: () => grid,
-  mode: 'display',
-  block_size: blockSize,
-  // light gray
-  block_color: '#878A8C',
-  highlight_color: '#007fff',
-  data: {
-    assessment_stage: 'dev',
-  },
-  on_load: () => {
-    const container = document.getElementById('jspsych-corsi-stimulus');
-    container.id = '';
-    container.classList.add('jspsych-corsi-overide');
+// This function produces both the display and input trials for the corsi blocks
+export function getCorsiBlocks({mode}) {
+  return {
+    type: jsPsychCorsiBlocks,
+    sequence: () => generatedSequence,
+    blocks: () => grid,
+    mode: mode,
+    block_size: blockSize,
+    // light gray
+    // Must be specified here as well as in the stylesheet. This is because
+    // We need it for the initial render (our code) and when jspsych changes the color after highlighting.
+    block_color: 'rgba(215, 215, 215, 0.93)',
+    highlight_color: '#275BDD',
+    data: {
+      // not camelCase because firekit
+      save_trial: mode === 'input',
+      assessment_stage: 'memory-game',
+      // not for firekit
 
-    container.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
-    container.style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
+      // TBD: Will memory game have practice trials?
+      // isPracticeTrial: true,
+    },
+    on_load: () => doOnLoad(mode),
+    on_finish: (data) => {
+      if (mode === 'input') {
+        jsPsych.data.addDataToLastTrial({
+          correct: _isEqual(data.response, data.sequence)
+        });
 
-    const blocks = document.getElementsByClassName('jspsych-corsi-block');
+        generatedSequence = generateRandomSequence(numOfblocks, sequenceLength);
+      }
+    },
+  }
+} 
 
-    Array.from(blocks).forEach((element, i) => {
-      // Cannot just remove the id because the trial code uses that under the hood
-      // so must remove css properties manually
-      element.style.top = `unset`;
-      element.style.left = `unset`;
-      element.style.transform = `none`;
-      element.style.position = `unset`;
-      element.style.width = `unset`;
-      element.style.height = `unset`;
+function doOnLoad(mode) {
+  const container = document.getElementById('jspsych-corsi-stimulus');
+  container.id = '';
+  container.classList.add('jspsych-corsi-overide');
 
-      element.classList.add('jspsych-corsi-block-overide');
-    });
+  container.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
+  container.style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
 
-    const contentWrapper = document.getElementById('jspsych-content');
+  const blocks = document.getElementsByClassName('jspsych-corsi-block');
 
-    const prompt = document.createElement('p');
-    prompt.textContent = 'Watch the blocks light up';
-    contentWrapper.appendChild(prompt);
-  },
-  on_finish: () => {
-    jsPsych.data.addDataToLastTrial({
-      correct: 'sure',
-    });
-  },
-};
+  Array.from(blocks).forEach((element, i) => {
+    // Cannot just remove the id because the trial code uses that under the hood
+    // so must remove css properties manually
+    element.style.top = `unset`;
+    element.style.left = `unset`;
+    element.style.transform = `none`;
+    element.style.position = `unset`;
+    element.style.width = `unset`;
+    element.style.height = `unset`;
 
-export const corsiBlocks = {
-  type: jsPsychCorsiBlocks,
-  sequence: () => generatedSequence,
-  blocks: () => grid,
-  mode: 'input',
-  block_size: blockSize,
-  // light gray
-  block_color: '#878A8C',
-  highlight_color: '#007fff',
-  data: {
-    assessment_stage: 'dev',
-  },
-  on_load: () => {
-    const container = document.getElementById('jspsych-corsi-stimulus');
-    container.id = '';
-    container.classList.add('jspsych-corsi-overide');
+    element.classList.add('jspsych-corsi-block-overide');
+  });
 
-    container.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
-    container.style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
+  const contentWrapper = document.getElementById('jspsych-content');
+  const corsiBlocksHTML = contentWrapper.children[1];
 
-    const blocks = document.getElementsByClassName('jspsych-corsi-block');
-
-    Array.from(blocks).forEach((element, i) => {
-      element.style.top = `unset`;
-      element.style.left = `unset`;
-      element.style.transform = `none`;
-      element.style.position = `unset`;
-      element.style.width = `unset`;
-      element.style.height = `unset`;
-
-      element.classList.add('jspsych-corsi-block-overide');
-    });
-
-    const contentWrapper = document.getElementById('jspsych-content');
-
-    const prompt = document.createElement('p');
-    prompt.textContent = 'Select the squares in the order that was highlighted';
-    contentWrapper.appendChild(prompt);
-  },
-  on_finish: () => {
-    jsPsych.data.addDataToLastTrial({
-      correct: 'sure',
-    });
-    console.log({ generatedSequence });
-    generatedSequence = generateRandomSequence(numOfblocks, sequenceLength);
-  },
-};
+  const prompt = document.createElement('p');
+  prompt.classList.add('corsi-block-overide-prompt')
+  prompt.textContent = mode === 'display' ? 'Watch the blocks light up' : 'Select the squares in the order that was highlighted';
+  // Inserting element at the second child position rather than
+  // changing the jspsych-content styles to avoid potential issues in the future
+  contentWrapper.insertBefore(prompt, corsiBlocksHTML);
+}

--- a/task-launcher/src/tasks/memory-game/trials/stimulus.js
+++ b/task-launcher/src/tasks/memory-game/trials/stimulus.js
@@ -15,6 +15,7 @@ const blockSpacing = 0.5;
 const sequenceLength = age > 6 ? 4 : 2;
 const grid = createGrid(x, y, numOfblocks, blockSize, gridSize, blockSpacing);
 let generatedSequence = generateRandomSequence(numOfblocks, sequenceLength);
+let selectedCoordinates = [];
 
 // This function produces both the display and input trials for the corsi blocks
 export function getCorsiBlocks({mode}) {
@@ -42,8 +43,10 @@ export function getCorsiBlocks({mode}) {
     on_finish: (data) => {
       if (mode === 'input') {
         jsPsych.data.addDataToLastTrial({
-          correct: _isEqual(data.response, data.sequence)
+          correct: _isEqual(data.response, data.sequence),
+          selectedCoordinates: selectedCoordinates
         });
+        selectedCoordinates = [];
 
         generatedSequence = generateRandomSequence(numOfblocks, sequenceLength);
       }
@@ -72,6 +75,12 @@ function doOnLoad(mode) {
     element.style.height = `unset`;
 
     element.classList.add('jspsych-corsi-block-overide');
+
+    if (mode === 'input') {
+      element.addEventListener('click', (event) => {
+        selectedCoordinates.push([event.clientX, event.clientY])
+      })
+    }
   });
 
   const contentWrapper = document.getElementById('jspsych-content');

--- a/task-launcher/src/tasks/shared/helpers/initTrialSaving.js
+++ b/task-launcher/src/tasks/shared/helpers/initTrialSaving.js
@@ -23,6 +23,10 @@ export const initTrialSaving = (config) => {
 
   jsPsych.opts.on_data_update = extend(jsPsych.opts.on_data_update, (data) => {
     if (data.save_trial) {
+      // save_trial is a flag that indicates whether the trial should
+      // be saved to Firestore. No point in writing it to the db.
+      delete data.save_trial;
+      delete data.internal_node_id;
       config.firekit.writeTrial(data);
     }
   });


### PR DESCRIPTION
- Adding styling to stimulus trials from Figma
- Pulled out on_load code into a function
- Abstracted corsi block trials into a function that returns the trials, similar to afcStimulus.
- Updated data saved to Firestore. No longer saving save_trial flag and internal node id from jsPsych.