### PR TITLE
Add storeId parameter. Fix corpus shuffling when sequentialTrials=false

### DIFF
--- a/task-launcher/README.md
+++ b/task-launcher/README.md
@@ -83,6 +83,8 @@ numOfPracticeTrials: [number] (optional),
 maxIncorrect: [number] (optional),
 maxTime: [number] (optional),
 keyHelpers: [boolean] (optional)
+storeItemId: [boolean] (optional)
+
 ```
 
 ### Math (includes Number Line) - Default

--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -27,6 +27,9 @@ const keyHelpers = stringToBoolean(urlParams.get('keyHelpers'), true);
 const skipInstructions = stringToBoolean(urlParams.get('skip'), true);
 const sequentialPractice = stringToBoolean(urlParams.get('sequentialPractice'), true);
 const sequentialStimulus = stringToBoolean(urlParams.get('sequentialStimulus'), true);
+const storeItemId = stringToBoolean(urlParams.get('storeItemId'), false);
+
+
 const { language } = i18next;
 // const story = stringToBoolean(urlParams.get("story"));
 
@@ -57,6 +60,7 @@ onAuthStateChanged(appKit.auth, (user) => {
       language,
       age,
       maxTime,
+      storeItemId,
       // story,
       // storyCorpus,
     };

--- a/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
+++ b/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
@@ -16,9 +16,6 @@ export let corpora;
 
 let totalTrials = 0;
 
-// TODO: Remove (DEPRECATED)
-let maxPracticeTrials = 0;
-
 let stimulusData = [],
   practiceData = [];
 
@@ -48,6 +45,7 @@ const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
       // for testing, will be removed
       prompt: row.prompt,
       item: writeItem(row),
+      origItemNum: row.orig_item_num,
       trialType: row.trial_type,
       image: row.image,
       timeLimit: row.time_limit,
@@ -66,33 +64,25 @@ const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
       newRow.distractors = newRow.distractors.map((choice) => camelize(choice));
     }
 
-    totalTrials += 1;
-
-    if (row.notes === 'practice') {
-      totalPractice += 1;
-    }
-
     let currentTrialType = newRow.trialType;
-
-    // console.log('currentTrialType:', currentTrialType)
-    // console.log('currTrialTypeBlock:', currTrialTypeBlock)
-
     if (currentTrialType !== currTrialTypeBlock) {
       currTrialTypeBlock = currentTrialType;
       currPracticeAmount = 0;
     }
 
-    // Only push in the specified amount of practice trials
-    if (newRow.notes !== 'practice') {
+    if (newRow.notes === 'instructions') {
       stimulusData.push(newRow);
+      totalTrials += 1
     } else if (newRow.notes === 'practice' && currPracticeAmount < numOfPracticeTrials) {
+      // Only push in the specified amount of practice trials
       stimulusData.push(newRow);
       currPracticeAmount += 1;
+      totalTrials += 1
+    } else if (newRow.notes !== 'practice') {
+      stimulusData.push(newRow);
+      totalTrials += 1
     }
   });
-
-  // Adjust totalTrials to account for practice trials that might not be added
-  totalTrials -= totalPractice - numOfPracticeTrials;
 
   if (!sequentialStimulus) {
     stimulusData = shuffleStimulusTrials(stimulusData);
@@ -144,8 +134,6 @@ export const fetchAndParseCorpus = async (config) => {
       await parseCSVs(urls);
       store.session.set('totalTrials', totalTrials);
 
-      if (numOfPracticeTrials > maxPracticeTrials) config.numOfPracticeTrials = maxPracticeTrials;
-
       store.session.set('config', config);
     } catch (error) {
       console.error('Error:', error);
@@ -156,7 +144,7 @@ export const fetchAndParseCorpus = async (config) => {
 
   const csvTransformed = {
     practice: sequentialPractice ? practiceData : _shuffle(practiceData),
-    stimulus: sequentialStimulus ? stimulusData : _shuffle(stimulusData),
+    stimulus: stimulusData,  // previously shuffled by shuffleStimulusTrials
   };
 
   corpora = {
@@ -165,6 +153,5 @@ export const fetchAndParseCorpus = async (config) => {
   };
 
   // console.log({corpora})
-
   store.session.set('corpora', corpora);
 };

--- a/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
+++ b/task-launcher/src/tasks/shared/helpers/fetchAndParseCorpus.js
@@ -16,8 +16,7 @@ export let corpora;
 
 let totalTrials = 0;
 
-let stimulusData = [],
-  practiceData = [];
+let stimulusData = [];
 
 function writeItem(row) {
   if (row.task === 'math' && row.trial_type.includes('Number Line')) {
@@ -70,15 +69,15 @@ const transformCSV = (csvInput, numOfPracticeTrials, sequentialStimulus) => {
       currPracticeAmount = 0;
     }
 
-    if (newRow.notes === 'instructions') {
-      stimulusData.push(newRow);
-      totalTrials += 1
-    } else if (newRow.notes === 'practice' && currPracticeAmount < numOfPracticeTrials) {
-      // Only push in the specified amount of practice trials
-      stimulusData.push(newRow);
-      currPracticeAmount += 1;
-      totalTrials += 1
-    } else if (newRow.notes !== 'practice') {
+    if (newRow.notes === 'practice') { 
+      if (currPracticeAmount < numOfPracticeTrials) {
+        // Only push in the specified amount of practice trials
+        currPracticeAmount += 1;
+        stimulusData.push(newRow);
+        totalTrials += 1
+      } // else skip extra practice
+    } else {
+      // instruction and stimulus
       stimulusData.push(newRow);
       totalTrials += 1
     }
@@ -143,7 +142,6 @@ export const fetchAndParseCorpus = async (config) => {
   await fetchData();
 
   const csvTransformed = {
-    practice: sequentialPractice ? practiceData : _shuffle(practiceData),
     stimulus: stimulusData,  // previously shuffled by shuffleStimulusTrials
   };
 

--- a/task-launcher/src/tasks/shared/helpers/initConfig.js
+++ b/task-launcher/src/tasks/shared/helpers/initConfig.js
@@ -34,6 +34,7 @@ export const initSharedConfig = async (firekit, gameParams, userParams, displayE
     keyHelpers,
     age,
     maxTime, // maximum app duration in minutes
+    storeItemId,
     // storyCorpus,
     // story,
   } = cleanParams;
@@ -58,6 +59,7 @@ export const initSharedConfig = async (firekit, gameParams, userParams, displayE
     keyHelpers: keyHelpers ?? true,
     language: i18next.language,
     maxTime: maxTime || null, // default is no time limit
+    storeItemId: storeItemId,
     // storyCorpus: storyCorpus ?? 'story-lion',
     // story: story ?? false,
   };

--- a/task-launcher/src/tasks/shared/helpers/randomizeStimulusBlocks.js
+++ b/task-launcher/src/tasks/shared/helpers/randomizeStimulusBlocks.js
@@ -4,7 +4,7 @@ export function shuffleStimulusTrials(trialArray) {
   // 1. Group stimulus trials by type
   const stimulusTrialsByType = {};
   for (const trial of trialArray) {
-    if (trial.trialType !== ' instructions' && trial.notes !== 'practice') {
+    if (trial.trialType !== 'instructions' && trial.notes !== 'practice') {
       const trialType = trial.trialType; // Example property
       if (!stimulusTrialsByType[trialType]) {
         stimulusTrialsByType[trialType] = [];
@@ -22,7 +22,7 @@ export function shuffleStimulusTrials(trialArray) {
   // 3. Reintegrate shuffled stimulus trials into original array
   let index = 0;
   for (const trial of trialArray) {
-    if (trial.trialType !== ' instructions' && trial.notes !== 'practice') {
+    if (trial.trialType !== 'instructions' && trial.notes !== 'practice') {
       const trialType = trial.trialType;
       trialArray[index] = stimulusTrialsByType[trialType].shift();
     }

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.js
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.js
@@ -578,6 +578,14 @@ function doOnFinish(data, task) {
       responseType: store.session('responseType'),
     });
 
+   // corpusId and itemId fields are used by ROAR but not ROAD
+   if (store.session.get('config').storeItemId) {
+    jsPsych.data.addDataToLastTrial({
+        corpusId: store.session.get('config').corpus,
+        itemId: stimulus.source + "-" + stimulus.origItemNum,
+        });
+    }
+
     // Adding this seperately or otherwise it will overide
     // the response value added from practice trials
     if (stimulus.notes !== 'practice') {

--- a/task-launcher/src/tasks/trog/timeline.js
+++ b/task-launcher/src/tasks/trog/timeline.js
@@ -10,7 +10,6 @@ import { taskFinished } from './trials/instructions';
 
 export default function buildTROGTimeline(config, mediaAssets) {
   const preloadTrials = createPreloadTrials(mediaAssets).default;
-  // console.log({mediaAssets})
 
   initTrialSaving(config);
   const initialTimeline = initTimeline(config);
@@ -23,14 +22,6 @@ export default function buildTROGTimeline(config, mediaAssets) {
     task: config.task,
   };
 
-  // const practiceBlock = {
-  //   timeline: [
-  //     setupPractice,
-  //     afcStimulus(trialConfig)
-  //   ],
-  //   repetitions: config.numOfPracticeTrials
-  // }
-
   const stimulusBlock = {
     timeline: [setupStimulusConditional, afcStimulusWithTimeoutCondition(trialConfig)],
     repetitions: store.session.get('totalTrials'),
@@ -39,8 +30,6 @@ export default function buildTROGTimeline(config, mediaAssets) {
   const timeline = [
     preloadTrials,
     initialTimeline,
-    //instructions1, // TODO: fix audio and button
-    // practiceBlock,
     stimulusBlock,
   ];
 

--- a/task-launcher/src/tasks/trog/trials/instructions.js
+++ b/task-launcher/src/tasks/trog/trials/instructions.js
@@ -11,7 +11,7 @@ export const taskFinished = {
   },
   stimulus: `
     <div class='instructions-container'>
-        <h1 class='instructions-title'>You've completed the task -- thank you!</h1>
+        <h1 class='instructions-title'>You've completed the task. Thank you!</h1>
 
         <p>
             


### PR DESCRIPTION
Added parameter storeId.  When it is set, corpus and itemId fields will be added to the trial data that is saved to the database.

fetchAndParseCorpus.js: Fixed the reading of the corpus into stimulusData, preserving the original implementation of all trials going into the same structure.  The corpus used for roar-syntax will now set trial_type to stimulus for all items, so that they are randomly shuffled as one block.  Designations such as noun, verb, etc have been moved to the notes.   The trog-item-bank will continue to be shuffled only within each group of 4 items.