### PR TITLE
HaF: implement practice trial shortcut

### DIFF
--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -83,29 +83,6 @@ export default function buildHeartsAndFlowersTimeline(config, mediaAssets) {
     },
   };
 
-  // introductionTrials, ifNotFullscreen,
-  // const timeline = [
-  //   preloadTrials,
-  //   initialTimeline,
-  //   introduction,
-  //   heartInstructions,
-  //   heartPracticeBlock1,
-  //   heartPracticeBlock2,
-  //   timeToPractice,
-  //   heartPracticeTimeline,
-  //   heartPostPracticeBlock,
-  //   heartTimeline,
-  //   flowerInstructionsBlock,
-  //   flowerPracticeTimeline,
-  //   flowerPostPracticeBlock,
-  //   flowerTimeline,
-  //   heartsAndFlowersInstructionsBlock,
-  //   heartsAndFlowersPracticeTimeline,
-  //   heartsAndFlowersPostPracticeBlock,
-  //   heartsAndFlowersTimeline,
-  //   endGame,
-  //   exitFullscreen,
-  // ];
   let timeline = [
     preloadTrials,
     initialTimeline,
@@ -152,8 +129,6 @@ function getHeartOrFlowerSubtimelines(adminConfig, stimulusType) {
   return subtimelines;
 }
 
-//TODO: check that it's ok to not have full screen feedback in case of correct answer,
-// for both instruction practice trials and practice trials
 //TODO: check if we need to repeat the whole pair when user gets it wrong or if getting right on the feedback trial is enough
 function getHeartOrFlowerInstructionsSection(adminConfig, stimulusType) {
 
@@ -262,7 +237,12 @@ function getHeartOrFlowerPracticeSection(adminConfig, stimulusType) {
   subtimeline.push({
     timeline: [
       fixation(adminConfig.interStimulusInterval),
-      stimulus(true, jsPsychAssessmentStage, adminConfig.stimulusPresentationTime, onTrialFinishTimelineCallback),
+      stimulus(
+        true,
+        jsPsychAssessmentStage,
+        adminConfig.stimulusPresentationTime,
+        onTrialFinishTimelineCallback
+      ),
       practiceFeedback,
     ],
     timeline_variables: buildHeartsOrFlowersTimelineVariables(adminConfig.practiceTrialCount, stimulusType),
@@ -367,7 +347,7 @@ function getMixedPracticeSection(adminConfig) {
     ],
     timeline_variables: buildMixedTimelineVariables(adminConfig.practiceTrialCount),
     randomize_order: false,
-  }
+  };
 
   //TODO: do we really need to nest these into a sub-timeline?
   const heartsAndFlowersPostPracticeBlock = {

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -246,18 +246,33 @@ function getHeartOrFlowerPracticeSection(adminConfig, stimulusType) {
     ],
   };
 
+  // Let's prepare a callback to pass to our stimuli trials and keep track of successive correct practice trials
+  let practiceWinStreakCount = 0;
+  function onTrialFinishTimelineCallback(data) {
+    practiceWinStreakCount = data.correct ? practiceWinStreakCount+1 : 0;
+    console.log(`Practice block win streak=${practiceWinStreakCount}`);
+    if (practiceWinStreakCount >= adminConfig.correctPracticeTrial) {
+      console.log(`Ending practice block early: win streak=${practiceWinStreakCount}`);
+      jsPsych.endCurrentTimeline();
+    }
+  };
+
   const subtimeline = [];
   subtimeline.push(getTimeToPractice());
   subtimeline.push({
     timeline: [
       fixation(adminConfig.interStimulusInterval),
-      stimulus(true, jsPsychAssessmentStage, adminConfig.stimulusPresentationTime),
+      stimulus(true, jsPsychAssessmentStage, adminConfig.stimulusPresentationTime, onTrialFinishTimelineCallback),
       practiceFeedback,
     ],
     timeline_variables: buildHeartsOrFlowersTimelineVariables(adminConfig.practiceTrialCount, stimulusType),
     randomize_order: false,
-    //TODO: implement "end early" when user get multiple correct answer in a row = adminConfig.correctPracticeTrial
-    //TODO: implement adminConfig.stimulusPresentationTime and adminConfig.interStimulusInterval
+    //TODO: Let's standardize the way on_finish callbacks can be defined here vs in the trial object:
+    // here, only the "fixation" trial does not define an on_finish callback so it's the only one for which the
+    // below commented code would get executed.
+    // on_finish: (data) => {
+    //   console.error(data);
+    // },
   });
   subtimeline.push(postPracticeBlock);
 
@@ -284,7 +299,6 @@ function getHeartOrFlowerTestSection(adminConfig, stimulusType) {
     ],
     timeline_variables: buildHeartsOrFlowersTimelineVariables(adminConfig.testTrialCount, stimulusType),
     randomize_order: false,
-    //TODO: implement adminConfig.stimulusPresentationTime and adminConfig.interStimulusInterval
   });
   return subtimeline;
 }
@@ -329,16 +343,31 @@ function getMixedPracticeSection(adminConfig) {
   // flower-practice-feedback2, "When you see a FLOWER, press the button on the OPPOSITE side."
   const practiceFeedback = buildMixedPracticeFeedback('heartPracticeFeedback2', 'feedbackGoodJob', 'flowerPracticeFeedback2', 'feedbackGoodJob');
 
+  // Let's prepare a callback to pass to our stimuli trials and keep track of successive correct practice trials
+  let practiceWinStreakCount = 0;
+  function onTrialFinishTimelineCallback(data) {
+    practiceWinStreakCount = data.correct ? practiceWinStreakCount+1 : 0;
+    console.log(`Practice block win streak=${practiceWinStreakCount}`);
+    if (practiceWinStreakCount >= adminConfig.correctPracticeTrial) {
+      console.log(`Ending practice block early: win streak=${practiceWinStreakCount}`);
+      jsPsych.endCurrentTimeline();
+    }
+  };
+
   const heartsAndFlowersPracticeTimeline = {
     timeline: [
       fixation(adminConfig.interStimulusInterval),
-      stimulus(true, AssessmentStageType.HeartsAndFlowersPractice, adminConfig.stimulusPresentationTime),
+      stimulus(
+        true,
+        AssessmentStageType.HeartsAndFlowersPractice,
+        adminConfig.stimulusPresentationTime,
+        onTrialFinishTimelineCallback
+      ),
       practiceFeedback,
     ],
     timeline_variables: buildMixedTimelineVariables(adminConfig.practiceTrialCount),
     randomize_order: false,
-    //TODO: implement adminConfig.stimulusPresentationTime and adminConfig.interStimulusInterval
-  };
+  }
 
   //TODO: do we really need to nest these into a sub-timeline?
   const heartsAndFlowersPostPracticeBlock = {
@@ -360,7 +389,6 @@ function getMixedTestSection(adminConfig) {
     ],
     timeline_variables: buildMixedTimelineVariables(adminConfig.testTrialCount),
     randomize_order: false,
-    //TODO: implement adminConfig.stimulusPresentationTime and adminConfig.interStimulusInterval
 
     //TODO: Not sure what to do with this. Double check we don't need it
     // sample: {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
@@ -16,7 +16,7 @@ import shuffle from 'lodash/shuffle';
  *TODO: we should perhaps allow {@link https://www.jspsych.org/7.2/overview/media-preloading/#automatic-preloading automatic preload}
   of the stimulus image and modify the DOM nodes that jsPsych creates in on_load?
   */
-export function stimulus(isPractice = false, stage, stimulusDuration) {
+export function stimulus(isPractice, stage, stimulusDuration, onTrialFinishTimelineCallback = undefined ) {
   return {
     type: jsPsychHTMLMultiResponse,
     data: () => {
@@ -74,16 +74,20 @@ export function stimulus(isPractice = false, stage, stimulusDuration) {
       // record whether answer was correct or not
       const validAnswer = getCorrectInputSide(stimulusType, stimuluSide)
       data.correct = validAnswer === response;
+      //TODO: move these to timeline-level callback/variables
       store.session.set('correct', data.correct);
       store.session.set('stimulus', stimulusType);
       store.session.set('side', stimuluSide);
 
-      //TODO: Double check what needs to be save as this is fishy
       jsPsych.data.addDataToLastTrial({
         item: stimulusType,
         answer: validAnswer === 0? ResponseSideType.Left : ResponseSideType.Right,
         response: response === 0? ResponseSideType.Left : ResponseSideType.Right,
       });
+
+      if (onTrialFinishTimelineCallback) {
+        onTrialFinishTimelineCallback(data);
+      }
     },
 
     // DEFAULTS


### PR DESCRIPTION
correctPracticeTrial value is read from admin config defined here (as of now it's 2, 2, and 3 for Hearts, Flowers, and Mixed practice blocks respectively): https://github.com/levante-framework/core-tasks/blob/044690ebfd37b6d405a233ceeb9aa13f32fb10bf/task-launcher/src/tasks/hearts-and-flowers/timeline.js#L54-L85