### PR TITLE
HaF: delay exiting the nested practice timeline to its feedback trial

### DIFF
--- a/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
@@ -92,16 +92,16 @@ export function buildInstructionPracticeTrial(stimulusType, promptText, promptAu
  * Builds a feedback trial for cases where the feedback prompt may change only depending on
  * whether the answer was correct or incorrect.
  */
-export function buildStimulusInvariantPracticeFeedback(feedbackPromptIncorrectKey, feedbackPromptCorrectKey) {
-  return buildPracticeFeedback(feedbackPromptIncorrectKey, feedbackPromptCorrectKey, feedbackPromptIncorrectKey, feedbackPromptCorrectKey);
+export function buildStimulusInvariantPracticeFeedback(feedbackPromptIncorrectKey, feedbackPromptCorrectKey, onFinishTimelineCallback=undefined) {
+  return buildPracticeFeedback(feedbackPromptIncorrectKey, feedbackPromptCorrectKey, feedbackPromptIncorrectKey, feedbackPromptCorrectKey, onFinishTimelineCallback);
 }
 
 /**
  * Builds a feedback trial for cases where the feedback prompt may change depending on
  * the stimulus type and whether the answer was correct or incorrect.
  */
-export function buildMixedPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey) {
-  return buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey)
+export function buildMixedPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey, onFinishTimelineCallback=undefined) {
+  return buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey, onFinishTimelineCallback)
 }
 
 //TODO: rely on previous trial data instead of singleton store to pass stimulus type, side and correct answer.
@@ -117,7 +117,8 @@ export function buildMixedPracticeFeedback(heartFeedbackPromptIncorrectKey, hear
 /**
  * Builds a feedback trial for instructions practice trials and practice trials.
  */
-function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey) {
+function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPromptCorrectKey, flowerFeedbackPromptIncorrectKey, flowerfeedbackPromptCorrectKey,
+  onFinishTimelineCallback) {
   const validAnswerButtonHtmlIdentifier = 'valid-answer-btn';
   const feedbackTexts = {
     IncorrectHeart:   store.session.get('translations')[heartFeedbackPromptIncorrectKey],
@@ -226,6 +227,11 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
     response_ends_trial: () => {
       // when showing incorrect feedback, the trial should only end with response
       return store.session.get('correct') === false ? true : false;
+    },
+    on_finish: (data) => {
+      if (onFinishTimelineCallback) {
+        onFinishTimelineCallback(data);
+      }
     },
   };
   overrideAudioTrialForReplayableAudio(trial, jsPsych.pluginAPI, replayButtonHtmlId);


### PR DESCRIPTION
When hitting the "winning-streak" on practice blocks (as of now it is 3 for mixed stimuli practice and 2 for the non-mixed)
We end the practice block nested timeline early via callbacks from the stimulus trial.
Problem: we skip the last feedback trial.

This makes sure this last feedback trial is shown before we exit the nested timeline early.