### PR TITLE
Adding a way to disable the replay button for the initial stimulus time

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -148,6 +148,17 @@ button {
       background-color: rgba($bg-button-primary-clicked, 0.6);
       border: 2px solid $border-button-primary-clicked;
     }
+
+    &:disabled {
+      background-color: rgba($bg-white-40, 0.6);
+      border: 2px solid $border-grey;
+      pointer-events: none;
+      svg {
+        path {
+          fill: $border-grey;
+        }
+      }
+    }
   }
 
   &.image {

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.js
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.js
@@ -112,7 +112,6 @@ export const slider = {
   step: 'any',
   // response_ends_trial: true,
   on_load: () => {
-    console.log('mark://', taskStore().nextStimulus.trialType);
     const slider = document.getElementById('jspsych-html-slider-response-response');
     slider.classList.add('custom-slider');
 

--- a/task-launcher/src/tasks/shared/helpers/audioHandler.ts
+++ b/task-launcher/src/tasks/shared/helpers/audioHandler.ts
@@ -1,0 +1,47 @@
+//@ts-ignore
+import { jsPsych } from '../../taskSetup';
+
+export class PageAudioHandler {
+  constructor() {
+    throw new Error('Cannot initialize the singleton static class PageAudioHandler');
+  }
+
+  static audioContext: BaseAudioContext;
+  static audioUri: string;
+  static audioSource?: AudioBufferSourceNode;
+
+  static stopAndDisconnectNode() {
+    if (PageAudioHandler.audioSource) {
+      PageAudioHandler.audioSource.stop();
+      PageAudioHandler.audioSource.disconnect();
+      PageAudioHandler.audioSource = undefined;
+    }
+  }
+
+  static async playAudio(audioUri: string, overridePlay: boolean, onEnded?: Function) {
+    if (PageAudioHandler?.audioSource) {
+      if (!overridePlay) {
+        // currently an audioSource is playing
+        return;
+      } else {
+        PageAudioHandler.stopAndDisconnectNode();
+      }
+    }
+
+    PageAudioHandler.audioUri = audioUri;
+    const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
+    // Returns a promise of the AudioBuffer of the preloaded file path.
+    const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(audioUri);
+    const audioSource: AudioBufferSourceNode = jsPsychAudioCtx.createBufferSource();
+    PageAudioHandler.audioSource = audioSource;
+    audioSource.buffer = audioBuffer;
+    audioSource.connect(jsPsychAudioCtx.destination);
+    audioSource.onended = () => {
+      PageAudioHandler.stopAndDisconnectNode();
+      if (onEnded) {
+        onEnded();
+      }
+    };
+    audioSource.start(0);
+  }
+}

--- a/task-launcher/src/tasks/shared/helpers/index.js
+++ b/task-launcher/src/tasks/shared/helpers/index.js
@@ -23,3 +23,4 @@ export * from './components'
 export * from './replayAudio';
 export * from './loadingScreen';
 export * from './setSkipCurrentBlock'
+export { PageAudioHandler } from './audioHandler';

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.js
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.js
@@ -1,6 +1,5 @@
 // For all tasks except: H&F, Memory Game, Same Different Selection
 import jsPsychAudioMultiResponse from '@jspsych-contrib/plugin-audio-multi-response';
-import store from 'store2';
 import { jsPsych, isTouchScreen } from '../../taskSetup';
 import {
   prepareChoices,
@@ -11,6 +10,7 @@ import {
   setupReplayAudio,
   setSkipCurrentBlock,
   taskStore,
+  PageAudioHandler,
 } from '../../shared/helpers';
 import { mediaAssets } from '../../..';
 import _toNumber from 'lodash/toNumber';
@@ -30,13 +30,7 @@ let startTime;
 const incorrectPracticeResponses = [];
 
 const playAudio = async (audioUri) => {
-  const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
-  // Returns a promise of the AudioBuffer of the preloaded file path.
-  const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(audioUri);
-  const audioSource = jsPsychAudioCtx.createBufferSource();
-  audioSource.buffer = audioBuffer;
-  audioSource.connect(jsPsychAudioCtx.destination);
-  audioSource.start(0);
+  PageAudioHandler.playAudio(audioUri, false);
 };
 
 const showStaggeredBtnAndPlaySound = (btn) => {
@@ -271,15 +265,16 @@ async function keyboardBtnFeedback(e, practiceBtns, stim) {
       }
     });
 
-    const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
+    // const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
 
     // Returns a promise of the AudioBuffer of the preloaded file path.
-    const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(feedbackAudio);
+    PageAudioHandler.playAudio(feedbackAudio, false);
+    // const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(feedbackAudio);
 
-    audioSource = jsPsychAudioCtx.createBufferSource();
-    audioSource.buffer = audioBuffer;
-    audioSource.connect(jsPsychAudioCtx.destination);
-    audioSource.start(0);
+    // audioSource = jsPsychAudioCtx.createBufferSource();
+    // audioSource.buffer = audioBuffer;
+    // audioSource.connect(jsPsychAudioCtx.destination);
+    // audioSource.start(0);
   }
 }
 
@@ -474,7 +469,7 @@ function doOnLoad(task) {
 }
 
 function doOnFinish(data, task) {
-  if (audioSource) audioSource.stop();
+  PageAudioHandler.stopAndDisconnectNode();
 
   // note: nextStimulus is actually the current stimulus
   const stimulus = taskStore().nextStimulus;


### PR DESCRIPTION
This PR addresses the following:
1. Disables the replay button when the initial stimulus audio is playing
2. Disables the replay button when the replay button is played and audio is playing
3. Centralizes the audio logic into a singleton so that audios don't overlap
4. Update the replay button styles to show that the button is disabled