### PR TITLE
Consolidating afcstimulus audio to page audio handler

### DIFF
--- a/task-launcher/src/tasks/shared/helpers/audioHandler.ts
+++ b/task-launcher/src/tasks/shared/helpers/audioHandler.ts
@@ -18,16 +18,7 @@ export class PageAudioHandler {
     }
   }
 
-  static async playAudio(audioUri: string, overridePlay: boolean, onEnded?: Function) {
-    if (PageAudioHandler?.audioSource) {
-      if (!overridePlay) {
-        // currently an audioSource is playing
-        return;
-      } else {
-        PageAudioHandler.stopAndDisconnectNode();
-      }
-    }
-
+  static async playAudio(audioUri: string, onEnded?: Function) {
     PageAudioHandler.audioUri = audioUri;
     const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
     // Returns a promise of the AudioBuffer of the preloaded file path.
@@ -37,7 +28,7 @@ export class PageAudioHandler {
     audioSource.buffer = audioBuffer;
     audioSource.connect(jsPsychAudioCtx.destination);
     audioSource.onended = () => {
-      PageAudioHandler.stopAndDisconnectNode();
+      // PageAudioHandler.stopAndDisconnectNode();
       if (onEnded) {
         onEnded();
       }

--- a/task-launcher/src/tasks/shared/helpers/replayAudio.js
+++ b/task-launcher/src/tasks/shared/helpers/replayAudio.js
@@ -4,7 +4,7 @@ import { camelize } from "@bdelab/roar-utils";
 import { PageAudioHandler } from "./audioHandler";
 
 
-export async function setupReplayAudio(audioSource, audioFile) {
+export async function setupReplayAudio(audioFile) {
   // Hardcoded since it uses the replayButtonDiv comopnent
   const replayBtn = document.getElementById('replay-btn-revisited');
 
@@ -26,7 +26,7 @@ export async function setupReplayAudio(audioSource, audioFile) {
 
     async function replayAudio() {
       replayBtn.disabled = true;
-      PageAudioHandler.playAudio(audioUri, false, onAudioEnd);
+      PageAudioHandler.playAudio(audioUri, onAudioEnd);
     }
 
     replayBtn.addEventListener('click', replayAudio);

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.js
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.js
@@ -23,14 +23,13 @@ let currPracticeChoiceMix = [];
 let currPracticeAnswerIdx;
 let trialsOfCurrentType = 0;
 
-let audioSource;
 let keyboardResponseMap = {};
 // Only used for keyboard responses
 let startTime;
 const incorrectPracticeResponses = [];
 
 const playAudio = async (audioUri) => {
-  PageAudioHandler.playAudio(audioUri, false);
+  PageAudioHandler.playAudio(audioUri);
 };
 
 const showStaggeredBtnAndPlaySound = (btn) => {
@@ -265,16 +264,8 @@ async function keyboardBtnFeedback(e, practiceBtns, stim) {
       }
     });
 
-    // const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
-
     // Returns a promise of the AudioBuffer of the preloaded file path.
-    PageAudioHandler.playAudio(feedbackAudio, false);
-    // const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(feedbackAudio);
-
-    // audioSource = jsPsychAudioCtx.createBufferSource();
-    // audioSource.buffer = audioBuffer;
-    // audioSource.connect(jsPsychAudioCtx.destination);
-    // audioSource.start(0);
+    PageAudioHandler.playAudio(feedbackAudio);
   }
 }
 
@@ -345,15 +336,7 @@ function doOnLoad(task) {
           }
         }
 
-        const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
-
-        // Returns a promise of the AudioBuffer of the preloaded file path.
-        const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(feedbackAudio);
-
-        audioSource = jsPsychAudioCtx.createBufferSource();
-        audioSource.buffer = audioBuffer;
-        audioSource.connect(jsPsychAudioCtx.destination);
-        audioSource.start(0);
+        PageAudioHandler.playAudio(feedbackAudio);
       }),
     );
 
@@ -465,7 +448,7 @@ function doOnLoad(task) {
     }
   }
 
-  setupReplayAudio(audioSource, stim.audioFile);
+  setupReplayAudio(stim.audioFile);
 }
 
 function doOnFinish(data, task) {


### PR DESCRIPTION
I tried to make the PageAudioHandler a singleton so that only 1 audio plays at a given time but it looks like that may not be possible as of now. So this PR essentially restores the previous behavior of audio overlap between feedback and replay button. However, we are still keeping the behavior of the replay button being disabled while the audio instruction is being played. Here are my two future solutions:
1. Move out the audio stimulus from `jsPsychAudioMultiResponse` and handle the entire audio on our end. (Gives us the most options)
2. Disable the feedback buttons while the audio instructions are playing and disable replay button while the feedback audio is playing (not ideal and will lead to some bad UX)