### PR TITLE
fix(): fixing the trial loops of haf

### DIFF
--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -183,17 +183,11 @@ function getHeartOrFlowerInstructionsSection(adminConfig, stimulusType) {
   // Instruction practice trials do not advance until user gets it right
   subtimeline.push({
     timeline: [instructionPractice1, instructionPracticeFeedback],
-    loop_function: (data) => {
-      console.log('mark://', 'In loop', taskStore().correct === false, taskStore().correct, taskStore().isCorrect);
-      return taskStore().isCorrect === false;
-    }
+    loop_function: () => taskStore().isCorrect === false,
   });
   subtimeline.push({
     timeline: [instructionPractice2, instructionPracticeFeedback],
-    loop_function: (data) => {
-      console.log('mark://', 'In loop', taskStore().correct === false);
-      return taskStore().isCorrect === false;
-    }
+    loop_function: () => taskStore().isCorrect === false,
   });
 
   return subtimeline;

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -183,11 +183,17 @@ function getHeartOrFlowerInstructionsSection(adminConfig, stimulusType) {
   // Instruction practice trials do not advance until user gets it right
   subtimeline.push({
     timeline: [instructionPractice1, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().correct === false,
+    loop_function: (data) => {
+      console.log('mark://', 'In loop', taskStore().correct === false, taskStore().correct, taskStore().isCorrect);
+      return taskStore().isCorrect === false;
+    }
   });
   subtimeline.push({
     timeline: [instructionPractice2, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().correct === false,
+    loop_function: (data) => {
+      console.log('mark://', 'In loop', taskStore().correct === false);
+      return taskStore().isCorrect === false;
+    }
   });
 
   return subtimeline;
@@ -307,11 +313,11 @@ function getMixedInstructionsSection(adminConfig) {
   // Instruction practice trials do not advance until user gets it right
   subtimeline.push({
     timeline: [instructionPractice1, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().correct === false,
+    loop_function: (data) => taskStore().isCorrect === false,
   });
   subtimeline.push({
     timeline: [instructionPractice2, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().correct === false,
+    loop_function: (data) => taskStore().isCorrect === false,
   });
 
   return subtimeline;

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
@@ -251,7 +251,7 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
       }
     },
     trial_ends_after_audio: () => {
-      // when showing correct feedback, the trial should end with the end of the audio
+      // always end practice trial after audio regardless of response
       return true;
     },
     on_finish: (data) => {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
@@ -8,7 +8,7 @@ import {
   getCorrectInputSide,
   getStimulusLayout
 } from '../helpers/utils';
-import { replayButtonSvg, overrideAudioTrialForReplayableAudio } from '../helpers/audioTrials';
+import { overrideAudioTrialForReplayableAudio } from '../helpers/audioTrials';
 import { taskStore } from '../../shared/helpers';
 
 /**
@@ -153,7 +153,6 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
       console.error(`buildPracticeFeedback: Missing feedback audio for ${key}`);
     }
   });
-  const replayButtonHtmlId = 'replay-btn-revisited';
 
   const trial = {
     type: jsPsychAudioMultiResponse,
@@ -174,9 +173,6 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
         const correctPrompt = StimulusType.Heart ? feedbackTexts.CorrectHeart : feedbackTexts.CorrectFlower;
         //TODO: consider removing the replay button from the correct feedback once we separate the correct and incorrect feedback
         return `
-          <button class="replay" id='${replayButtonHtmlId}'>
-            ${replayButtonSvg}
-          </button>
           <div class='haf-cr-container'>
             <img src='${mediaAssets.images.smilingFace}' />
             <p class='lev-text h4 primary'>${correctPrompt}</p>
@@ -192,7 +188,7 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
         imageSrc,
         taskStore().stimulusSide === StimulusSideType.Left,
         promptText,
-        replayButtonHtmlId,
+        false,
       )
     },
     prompt_above_buttons: true,
@@ -256,11 +252,7 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
     },
     trial_ends_after_audio: () => {
       // when showing correct feedback, the trial should end with the end of the audio
-      return taskStore().isCorrect === true ? true : false;
-    },
-    response_ends_trial: () => {
-      // when showing incorrect feedback, the trial should only end with response
-      return taskStore().isCorrect === false ? true : false;
+      return true;
     },
     on_finish: (data) => {
       if (onFinishTimelineCallback) {
@@ -268,6 +260,5 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
       }
     },
   };
-  overrideAudioTrialForReplayableAudio(trial, jsPsych.pluginAPI, replayButtonHtmlId);
   return trial;
 };


### PR DESCRIPTION
**Previous behavior (Practice):**
Incorrect response > show incorrect response > stay in the same trial with incorrect message > disable incorrect button (loop) > click correct response > go to next trial (good job screen is not shown in this case)

Correct response > good job screen > next trial

Additionally we show replay button in the incorrect and correct screen

**New behavior (Practice):**
Incorrect response > no replay button but the incorrect audio plays > loops back to the start of the instruction > correct response > show good job screen > next trial

Correct response > good job screen > next trial

No replay button shown since the screen are timed and the trial ends the moment audio stops and goes back to the instruction page (replay button is shown there)