### PR TITLE
Adds keyboard instruction screen

### DIFF
--- a/task-launcher/src/tasks/intro/trials/instructions.ts
+++ b/task-launcher/src/tasks/intro/trials/instructions.ts
@@ -27,6 +27,17 @@ const instructionData = [
     },
 ]
 
+// additional keyboard instructions for those not using a tablet
+if (!isTouchScreen) {
+    instructionData.push(
+        {
+            prompt: 'generalKeyboardInstructions',
+            image: 'avatarOwl',
+            buttonText: 'continueButtonText',
+        }
+    )
+}
+
 export const instructions = instructionData.map(data => {
     return {
         type: jsPsychAudioMultiResponse,


### PR DESCRIPTION
Adds a simple screen with instructions on how to use the keyboard to answer questions (the English text is "If you want to use your keyboard to answer a question, press the arrow key shown next to your choice."). It might be good if someone with a tablet could test to make sure the screen is not showing up for them. 

I also think it would be good to eventually replace the owl with a graphic that has an image of the arrow keys and example buttons with arrows next to them