### PR TITLE
Fix math answer saving

### DIFF
--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -403,9 +403,8 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
   // note: nextStimulus is actually the current stimulus
   const stimulus = taskStore().nextStimulus;
   const itemLayoutConfig = layoutConfigMap?.[stimulus.itemId];
-  // target is the actual value as a string
-  const target = taskStore().target;
   let responseValue = null
+  let target = null; 
 
   if (stimulus.trialType !== 'instructions') {
     if (itemLayoutConfig) {
@@ -418,7 +417,8 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
         ? keyboardChoices.findIndex(f => f.toLowerCase() === data.keyboard_response.toLowerCase())
         : data.button_response;
       responseValue = response.values[responseIndex];
-      data.correct = responseValue === response.target;
+      target = response.target; 
+      data.correct = responseValue === target;
     }
 
     // check response and record it


### PR DESCRIPTION
I think this fixes the issue where the answer for math trials was always being saved as 7/8. For some reason taskStore().target (which was previously being saved as the answer in the data) is 7/8 for all math trials, but the target value stored in layoutConfig is accurate. It might be good to eventually find out why taskStore doesn't have the right value, but this should fix the problem for now. 