### PR TITLE
Fix some response times not being saved in data

### DIFF
--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -12,6 +12,7 @@ import { mediaAssets } from '../../..';
 let chosenAnswer: number;
 let sliderStart: number;
 let keyboardResponseMap: Record<string, any> = {};
+let startTime: number; 
 
 function setUpAudio(responseType: string) {
   const cue = responseType === 'button' ? 'numberLinePrompt1' : 'numberLineSliderPrompt1';
@@ -118,6 +119,8 @@ export const slider = {
   step: 'any',
   // response_ends_trial: true,
   on_load: () => {
+    startTime = performance.now();
+
     const slider = document.getElementById('jspsych-html-slider-response-response') as HTMLButtonElement;
     const sliderLabels = document.getElementsByTagName('span') as HTMLCollectionOf<HTMLSpanElement>;
     Array.from(sliderLabels).forEach((el, i) => {
@@ -222,6 +225,7 @@ export const slider = {
   on_finish: (data: any) => {
     // Need to remove event listener after trial completion or they will stack and cause an error.
     document.removeEventListener('keydown', captureBtnValue);
+    const endTime = performance.now();
 
     const sliderScoringThreshold = 0.05 // proportion of maximum slider value that response must fall within to be scored correct
     const stimulus = taskStore().nextStimulus;
@@ -254,6 +258,14 @@ export const slider = {
       // slider_start: stimulus.item[1] === 1 ? sliderStart / 100 : sliderStart,
       slider_start: sliderStart,
     });
+
+    if (responseType === 'button') {
+      const calculatedRt = Math.round(endTime - startTime);
+
+      jsPsych.data.addDataToLastTrial({
+        rt: calculatedRt
+      });
+    }
   
     setSkipCurrentBlock(stimulus.trialType);
   },

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -9,6 +9,7 @@ import { finishExperiment } from '../../shared/trials';
 
 let selectedCards: string[] = [];
 let previousSelections: string[] = [];
+let startTime: number; 
 
 const replayButtonHtmlId = 'replay-btn-revisited';
 const SELECT_CLASS_NAME = 'info-shadow';
@@ -80,6 +81,8 @@ export const afcMatch = {
     // can select multiple cards and deselect them
     const stim = taskStore().nextStimulus;
     
+    startTime = performance.now();
+
     const audioFile = stim.audioFile;
     const pageStateHandler = new PageStateHandler(audioFile);
     setupReplayAudio(pageStateHandler);
@@ -118,6 +121,10 @@ export const afcMatch = {
   response_ends_trial: false,
   on_finish: () => {
     const stim = taskStore().nextStimulus;
+
+    const endTime = performance.now();
+    const calculatedRt = endTime - startTime; 
+
     // save data
     jsPsych.data.addDataToLastTrial({
       corpusTrialType: stim.trialType,
@@ -125,6 +132,7 @@ export const afcMatch = {
       response: selectedCards,
       distractors: stim.distractors,
       item: stim.item,
+      rt: Math.round(calculatedRt)
     });
 
     if (stim.audioFile.split('-')[2] === 'prompt1') {

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -203,13 +203,15 @@ export const stimulus = {
         response: choices[data.button_response],
       });
 
-      if (stim.trialType === "test-dimensions") {
+      if (stim.trialType === "test-dimensions" || stim.assessmentStage === 'practice_response') {
         const calculatedRt = Math.round(endTime - startTime);
 
         jsPsych.data.addDataToLastTrial({
           rt: calculatedRt
         })
       }
+
+      console.log(jsPsych.data.getLastTrialData().select('rt').values[0]);
 
       if ((taskStore().numIncorrect >= taskStore().maxIncorrect)) {
         finishExperiment();

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -9,6 +9,7 @@ import { jsPsych } from '../../taskSetup';
 
 const replayButtonHtmlId = 'replay-btn-revisited'; 
 let incorrectPracticeResponses: string[] = [];
+let startTime: number; 
 
 const generateImageChoices = (choices: string[]) => {
   return choices.map((choice) => {
@@ -144,6 +145,7 @@ export const stimulus = {
     taskStore().nextStimulus.trialType === 'test-dimensions' || taskStore().nextStimulus.assessmentStage === 'practice_response'
   ),
   on_load: () => {
+    startTime = performance.now();
     const audioFile = taskStore().nextStimulus.audioFile;
     const pageStateHandler = new PageStateHandler(audioFile);
     setupReplayAudio(pageStateHandler);
@@ -168,6 +170,7 @@ export const stimulus = {
   on_finish: (data: any) => {
     const stim = taskStore().nextStimulus;
     const choices = taskStore().choices;
+    const endTime = performance.now();
 
     // Always need to write correct key because of firekit.
     // TODO: Discuss with ROAR team to remove this check
@@ -199,6 +202,14 @@ export const stimulus = {
         corpusTrialType: stim.trialType,
         response: choices[data.button_response],
       });
+
+      if (stim.trialType === "test-dimensions") {
+        const calculatedRt = Math.round(endTime - startTime);
+
+        jsPsych.data.addDataToLastTrial({
+          rt: calculatedRt
+        })
+      }
 
       if ((taskStore().numIncorrect >= taskStore().maxIncorrect)) {
         finishExperiment();

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -203,7 +203,7 @@ export const stimulus = {
         response: choices[data.button_response],
       });
 
-      if (stim.trialType === "test-dimensions" || stim.assessmentStage === 'practice_response') {
+      if (stim.trialType === 'test-dimensions' || stim.assessmentStage === 'practice_response') {
         const calculatedRt = Math.round(endTime - startTime);
 
         jsPsych.data.addDataToLastTrial({

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -468,7 +468,7 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
 
     // adding manually since trial does not log it properly
     // for keyboard responses
-    if (responseType === 'keyboard' || data.response_source === 'keyboard') {
+    if (responseType === 'keyboard' || data.response_source === 'keyboard' || stimulus.assessmentStage === 'practice_response') {
       const endTime = performance.now();
       const calculatedRt = Math.round(endTime - startTime);
       jsPsych.data.addDataToLastTrial({


### PR DESCRIPTION
Response times were not being saved for some trials - as far as I can tell from looking at the jsPsych data object, these were the number line trials with buttons and the matching and test-dimensions phases of SDS. In this PR I manually calculated response times for these trials and added them to jsPsych.data (I saw this was also being done for keyboard responses in afcStimulus). I also noticed that RTs are not saved for practice trials - I'm not sure if we want those, but I could save them if that would be good! 