### PR TITLE
Update CSS to prevent content from leaving screen

### DIFF
--- a/task-launcher/src/styles/abstracts/_fonts.scss
+++ b/task-launcher/src/styles/abstracts/_fonts.scss
@@ -4,9 +4,9 @@ $font-size-l: 64px;
 $font-size-m: 48px;
 $font-size-s: 40px;
 $font-size-xs: 32px;
-$font-size-xs-em: 1.5em; 
 $font-size-xxs: 24px;
 $font-size-xxxs: 16px;
+$font-size-xs-em: clamp($font-size-xxxs, 1.4em, $font-size-xs); 
 
 $font-weight-dark: 700;
 $font-weight-bold: 600;

--- a/task-launcher/src/styles/abstracts/_variables.scss
+++ b/task-launcher/src/styles/abstracts/_variables.scss
@@ -11,7 +11,7 @@ $button-default-font-weight: 500;
 $button-secondary-box-shadow: -8px -10px 0px 0px;
 $button-secondary-inner-shadow: 0px 0px 12px 0px;
 
-$response-size-default: clamp(120px, 12vw, 150px);
-$response-size-sm: clamp(100px, 20vw, 150px);
-$response-size-s: 25vw;
+$response-size-default: clamp(120px, 10vw, 150px);
+$response-size-sm: clamp(100px, 18vw, 150px);
+$response-size-s: 22vw;
 $response-size-m: calc(clamp(70px, 22vw, 250px) - 10px);

--- a/task-launcher/src/styles/layout/_containers.scss
+++ b/task-launcher/src/styles/layout/_containers.scss
@@ -101,7 +101,8 @@
     border: 3px solid $bg-accent_secondary;
     border-radius: 32px;
     background-color: $bg-bubble-base;
-    max-width: 90vw;
+    width: 90vw;
+    max-width: max-content; 
 
     p {
       font-size: $font-size-xs-em;
@@ -118,7 +119,7 @@
       border-radius: 24px;
   
       p {
-        font-size: $font-size-xxs;
+        font-size: $font-size-xs-em;
         font-weight: $font-weight-light;
         line-height: 1.0;
         margin: 0;
@@ -133,7 +134,7 @@
       border-radius: 16px;
   
       p {
-        font-size: $font-size-xxxs;
+        font-size: $font-size-xs-em;
         font-weight: $font-weight-light;
         line-height: 1.0;
         margin: 0;

--- a/task-launcher/src/tasks/intro/trials/instructions.ts
+++ b/task-launcher/src/tasks/intro/trials/instructions.ts
@@ -45,7 +45,6 @@ export const instructions = instructionData.map(data => {
                         <img
                             src=${mediaAssets.images[data.image]}
                             alt='Instruction graphic'
-                            style="height:330px;width:330px"
                         />
                     </div>
                 </div>

--- a/task-launcher/src/tasks/matrix-reasoning/helpers/config.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/helpers/config.ts
@@ -23,6 +23,7 @@ export const getLayoutConfig = (
     value: stimulus.item,
     displayValue: undefined,
   };
+  defaultConfig.classOverrides.promptClassList = ['lev-row-container', 'instruction-small'];
   if (!defaultConfig.isInstructionTrial) {
     const prepChoices = prepareChoices(answer, distractors, true, trialType);
     defaultConfig.isImageButtonResponse = true;

--- a/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
@@ -25,7 +25,7 @@ export const instructions = instructionData.map(data => {
                         >
                             ${replayButtonSvg}
                         </button>
-                        <div class="lev-row-container instruction">
+                        <div class="lev-row-container instruction-small">
                             <p>${t[data.prompt]}</p>
                         </div>
 

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -122,6 +122,7 @@ const getPromptTemplate = (
   stimText: string | null | undefined,
   equalSizeStim: boolean,
   stimulusContainerClassList: string[],
+  promptClassList: string[]
 ) => {
   let template = '<div class="lev-stimulus-container">';
 
@@ -132,8 +133,13 @@ const getPromptTemplate = (
   `;
 
   if (prompt) {
+    let containerClass = "lev-row-container instruction"; 
+    if (promptClassList) {
+      containerClass = promptClassList.join(' ');
+    } 
+
     template += `
-      <div class="lev-row-container instruction">
+      <div class="${containerClass}">
         <p>${prompt}</p>
       </div>
     `;
@@ -183,7 +189,8 @@ function getPrompt(layoutConfigMap: Record<string, LayoutConfigType>) {
         enabled: promptEnabled,
       },
       classOverrides: {
-        stimulusContainerClassList
+        stimulusContainerClassList,
+        promptClassList
       },
       equalSizeStim,
       showStimImage,
@@ -203,6 +210,7 @@ function getPrompt(layoutConfigMap: Record<string, LayoutConfigType>) {
       stimText,
       equalSizeStim,
       stimulusContainerClassList,
+      promptClassList
     );
   }
 }

--- a/task-launcher/src/tasks/theory-of-mind/helpers/config.ts
+++ b/task-launcher/src/tasks/theory-of-mind/helpers/config.ts
@@ -20,6 +20,7 @@ export const getLayoutConfig = (
     value: stimulus.item,
     displayValue: undefined,
   };
+  defaultConfig.classOverrides.promptClassList = ['lev-row-container', 'instruction-small'];
   if (!defaultConfig.isInstructionTrial) {
     const prepChoices = prepareChoices(answer, distractors, true, trialType);
     defaultConfig.isStaggered = true;


### PR DESCRIPTION
The goal of this PR is to prevent the bottom buttons from leaving the screen, which was happening for matrix reasoning and TOM. I applied the `instruction-small` class to these tasks and also made each of the size variables for the `image` button class slightly smaller, which changes the size of the big stimulus images since they were previously set to 3x the size of the buttons. As far as I know `image` is currently only used for the buttons in these two tasks, so buttons in other tasks shouldn't be affected. I also slightly decreased the font size used for `instruction-small` and gave it min and max values. 