### PR TITLE
Fix audio issue caused by audioMultiResponse plugin

### DIFF
--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -75,7 +75,7 @@ const showStaggeredBtnAndPlaySound = (
 
 const handleStaggeredButtons = async (layoutConfig: LayoutConfigType, pageState: PageStateHandler) => {
   if (layoutConfig?.isStaggered) {
-      const parentResponseDiv = document.getElementById('jspsych-audio-multi-response-btngroup') as HTMLDivElement;
+      const parentResponseDiv = document.getElementById('jspsych-html-multi-response-btngroup') as HTMLDivElement;
       let i = 0;
       const stimulusDuration = await pageState.getStimulusDurationMs();
       const intialDelay = stimulusDuration + 300;
@@ -533,7 +533,7 @@ export const afcStimulusTemplate = (
 ) => {
   return {
     type: jsPsychHtmlMultiResponse,
-    //response_allowed_while_playing: responseAllowed,
+    response_allowed_while_playing: responseAllowed,
     data: () => {
       const stim = taskStore().nextStimulus;
       let isPracticeTrial = stim.assessmentStage === 'practice_response'; 
@@ -546,7 +546,6 @@ export const afcStimulusTemplate = (
       };
     },
     stimulus: () => getPrompt(layoutConfigMap),
-    //prompt: () => getPrompt(layoutConfigMap),
     prompt_above_buttons: promptAboveButtons,
     keyboard_choices: () => {
       const stim = taskStore().nextStimulus;

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -1,5 +1,5 @@
 // For all tasks except: H&F, Memory Game, Same Different Selection
-import jsPsychAudioMultiResponse from '@jspsych-contrib/plugin-audio-multi-response';
+import jsPsychHtmlMultiResponse from '@jspsych-contrib/plugin-html-multi-response';
 // @ts-ignore
 import { jsPsych, isTouchScreen } from '../../taskSetup';
 import {
@@ -329,6 +329,9 @@ function addKeyHelpers(el: HTMLElement, keyIndex: number) {
 }
 
 function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>) {
+  // play trial audio
+  PageAudioHandler.playAudio(getStimulus(layoutConfigMap)); 
+
   startTime = performance.now();
 
   const stim = taskStore().nextStimulus;
@@ -386,7 +389,7 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>) {
   }
 
   if (stim.trialType !== 'instructions') {
-    const buttonContainer = document.getElementById('jspsych-audio-multi-response-btngroup') as HTMLDivElement;
+    const buttonContainer = document.getElementById('jspsych-html-multi-response-btngroup') as HTMLDivElement;
     const responseButtons = buttonContainer.children as HTMLCollectionOf<HTMLButtonElement>;
     const totalResponseButtons = responseButtons.length;
     const { buttonLayout } = taskStore();
@@ -529,8 +532,8 @@ export const afcStimulusTemplate = (
   }
 ) => {
   return {
-    type: jsPsychAudioMultiResponse,
-    response_allowed_while_playing: responseAllowed,
+    type: jsPsychHtmlMultiResponse,
+    //response_allowed_while_playing: responseAllowed,
     data: () => {
       const stim = taskStore().nextStimulus;
       let isPracticeTrial = stim.assessmentStage === 'practice_response'; 
@@ -542,8 +545,8 @@ export const afcStimulusTemplate = (
         isPracticeTrial: isPracticeTrial,
       };
     },
-    stimulus: () => getStimulus(layoutConfigMap),
-    prompt: () => getPrompt(layoutConfigMap),
+    stimulus: () => getPrompt(layoutConfigMap),
+    //prompt: () => getPrompt(layoutConfigMap),
     prompt_above_buttons: promptAboveButtons,
     keyboard_choices: () => {
       const stim = taskStore().nextStimulus;


### PR DESCRIPTION
This PR switches to using the html-multi-response plugin in afcStimulus to avoid issues caused by the audio-multi-response plugin. The audio is now played using PageAudioHandler once the page loads. 