### PR TITLE
Fix memory game UI

### DIFF
--- a/task-launcher/src/styles/layout/_video-containers.scss
+++ b/task-launcher/src/styles/layout/_video-containers.scss
@@ -6,6 +6,11 @@ $instruction_m_size: 50vw;
 $instruction_sm_size: 70vw;
 $instruction_s_size: 80vw;
 
+$instruction_sm_default_size: 35vw;
+$instruction_sm_m_size: 45vw;
+$instruction_sm_sm_size: 65vw;
+$instruction_sm_s_size: 75vw;
+
 video {
   &.instruction-video {
     width: $instruction_default_size;
@@ -24,6 +29,22 @@ video {
     @include respond-to('small') {
       width: $instruction_s_size;
       margin-top: calc($ratio_difference * $instruction_s_size);
+    }
+  }
+
+  &.instruction-video-small {
+    width: $instruction_sm_default_size;
+
+    @include respond-to('medium') {
+      width: $instruction_m_size;
+    }
+
+    @include respond-to('small-medium') {
+      width: $instruction_sm_size;
+    }
+
+    @include respond-to('small') {
+      width: $instruction_s_size;
     }
   }
 }

--- a/task-launcher/src/tasks/memory-game/trials/instructions.ts
+++ b/task-launcher/src/tasks/memory-game/trials/instructions.ts
@@ -58,7 +58,7 @@ export const instructions = instructionData.map(data => {
                         </div>
                         <div class="lev-stim-content-x-3">
                             ${data.video ? 
-                                `<video class='instruction-video' autoplay loop>
+                                `<video class='instruction-video-small' autoplay loop>
                                     <source src=${mediaAssets.video[data.video]} type='video/mp4'>
                                 </video>` :
                                 `<img

--- a/task-launcher/src/tasks/memory-game/trials/instructions.ts
+++ b/task-launcher/src/tasks/memory-game/trials/instructions.ts
@@ -80,6 +80,7 @@ export const instructions = instructionData.map(data => {
             ]
         },
         keyboard_choices: 'NO_KEYS',
+        post_trial_gap: 500,
         on_load: () => {
             const pageStateHandler = new PageStateHandler(data.prompt);
             setupReplayAudio(pageStateHandler);


### PR DESCRIPTION
This PR addresses the comment from Germany that the OK button is leaving the screen during the instruction trials. I shrank the video size to create more room, which seems to solve the problem for most screen sizes. 

There was another comment about images briefly flashing on the screen before the instruction video. Because this stops happening after the task is reloaded a few times, I think it might be related to how the assets are loading (although I tried preloading the assets for memory game and it did not fix the issue). For now I added a short gap between instruction screens, which I think makes them easier to read and makes the image flickering less distracting when it does happen. 