### PR TITLE
Define pulse animation and disable buttons/key presses

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -121,6 +121,12 @@ button {
     border-color: $border-green_dark;
     box-shadow: $button-secondary-box-shadow $border-green_dark inset,
       $button-secondary-inner-shadow $bg-green-gradient inset;
+
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.1); }
+      100% { transform: scale(1); }
+    }
     
     @include respond-to('small') {
       font-size: $font-size-l;

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
@@ -195,11 +195,10 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
       document.getElementById('jspsych-html-multi-response-btngroup').classList.add('linear-4');
       const buttons = document.querySelectorAll('.secondary--green');
       buttons.forEach(button => {
+        button.disabled = true;
         if (button.id === validAnswerButtonHtmlIdentifier) {
           button.style.animation = 'pulse 2s infinite';
-        } else {
-          button.disabled = true;
-        }
+        } 
       });
 
       const audioAssetKey = getAssetKey();
@@ -208,17 +207,7 @@ function buildPracticeFeedback(heartFeedbackPromptIncorrectKey, heartfeedbackPro
       setupReplayAudio(pageStateHandler);
     },
     button_choices: [StimulusSideType.Left, StimulusSideType.Right],
-    keyboard_choices: () => {
-      if (isTouchScreen) return InputKey.NoKeys;
-      //else: allow keyboard input
-      if (taskStore().isCorrect === false) {
-        const validAnswerPosition = getCorrectInputSide(taskStore().stimulus, taskStore().stimulusSide);
-        return validAnswerPosition === 0?
-          InputKey.ArrowLeft : InputKey.ArrowRight;
-      } else {
-        return InputKey.AllKeys;
-      }
-    },
+    keyboard_choices: 'NO_KEYS',
     button_html: () => {
       if (taskStore().isCorrect === false) {
         const validAnswerPosition = getCorrectInputSide(taskStore().stimulus, taskStore().stimulusSide);


### PR DESCRIPTION
This PR fixes a bug in hearts and flowers caused by the user clicking the buttons during the incorrect feedback screen (for some reason this was causing the task to skip additional trials while the screen was still showing). I disabled the buttons and all key presses during feedback trials to prevent this, and also added the pulse animation back into the H&F button class. 