### PR TITLE
Fix audio overlap in matrix practice trials

### DIFF
--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -298,6 +298,8 @@ function handlePracticeButtonPress(
     setTimeout(() => enableBtns(practiceBtns), 500);
     incorrectPracticeResponses.push(choice);
   }
+  // if there is audio playing, stop it first before playing feedback audio to prevent overlap between trials
+  PageAudioHandler.stopAndDisconnectNode();
   PageAudioHandler.playAudio(feedbackAudio);
 }
 


### PR DESCRIPTION
This PR fixes an audio overlap issue that was happening in afcStimulus.ts practice trials - the prompt audio was carrying over to the next trial because it wasn't stopped (the practice audio was being stopped instead). The prompt audio now stops before the practice audio starts (so that clicking an answer interrupts the audio, like in test trials). 