### PR TITLE
CAT updates for downward extension

### DIFF
--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -46,7 +46,8 @@ const maxTime = urlParams.get('maxTime') === null ? null : parseInt(urlParams.ge
 const language = urlParams.get('lng');
 const pid = urlParams.get('pid');
 const inferenceNumStories = urlParams.get('inferenceNumStories') === null? null : parseInt(urlParams.get('inferenceNumStories'), 10);
-const semThreshold = Number(urlParams.get('semThreshold') || '0.5');
+const semThreshold = Number(urlParams.get('semThreshold') || '0');
+const startingTheta = Number(urlParams.get('theta') || '0'); 
 
 // Boolean parameters
 const keyHelpers = stringToBoolean(urlParams.get('keyHelpers'));
@@ -89,7 +90,8 @@ async function startWebApp() {
       storeItemId,
       cat,
       inferenceNumStories,
-      semThreshold
+      semThreshold, 
+      startingTheta
     };
 
       const taskInfo = {

--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -62,6 +62,7 @@ export type TaskStoreDataType = {
   inferenceNumStories?: number; // FIXME: Remove
   cat: boolean;
   semThreshold: number;
+  startingTheta: number;
   language?: string;
 };
 
@@ -92,6 +93,7 @@ export const setTaskStore = (config: TaskStoreDataType) => {
     keyHelpers: config.keyHelpers,
     runCat: config.cat, 
     semThreshold: config.semThreshold,
+    startingTheta: config.startingTheta, 
     storeItemId: config.storeItemId,
     isRoarApp: config.isRoarApp,
     numOfBlocks: config.userMetadata.age > 12 ? 9 : 4,

--- a/task-launcher/src/tasks/shared/helpers/config.ts
+++ b/task-launcher/src/tasks/shared/helpers/config.ts
@@ -78,7 +78,8 @@ export const setSharedConfig = async (firekit: RoarAppkit, gameParams: GameParam
     storeItemId,
     cat,
     inferenceNumStories,
-    semThreshold
+    semThreshold, 
+    startingTheta
   } = cleanParams;
 
   const config = {
@@ -104,7 +105,8 @@ export const setSharedConfig = async (firekit: RoarAppkit, gameParams: GameParam
     isRoarApp: isRoarApp(firekit),
     cat: !!cat ?? false,
     inferenceNumStories: Number(inferenceNumStories) || undefined,
-    semThreshold: Number(semThreshold) || 0
+    semThreshold: Number(semThreshold), 
+    startingTheta: Number(startingTheta)
   };
 
   // default corpus if nothing is passed in

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -5,6 +5,8 @@ import { taskStore } from '../../../taskStore';
 // separates trials from corpus into blocks for cat
 export function prepareCorpus(corpus: StimulusType[]) {
   const excludedTrialTypes = '3D'; 
+  // limit random starting items so that their difficulty is less than starting theta
+  const maxTrialDifficulty = taskStore().startingTheta; 
 
   const instructionPracticeTrials: StimulusType[] = corpus.filter(trial => 
     trial.assessmentStage === 'instructions' || trial.assessmentStage === 'practice_response'
@@ -14,7 +16,8 @@ export function prepareCorpus(corpus: StimulusType[]) {
     (trial.difficulty != null) &&
     !isNaN(Number(trial.difficulty)) &&
     !instructionPracticeTrials.includes(trial) &&
-    (trial.trialType !== excludedTrialTypes)
+    (trial.trialType !== excludedTrialTypes) &&
+    (trial.difficulty <= maxTrialDifficulty)
   )
   
   const startItems: StimulusType[] = selectNItems(possibleStartItems, 5);

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -5,8 +5,8 @@ import { taskStore } from '../../../taskStore';
 // separates trials from corpus into blocks for cat
 export function prepareCorpus(corpus: StimulusType[]) {
   const excludedTrialTypes = '3D'; 
-  // limit random starting items so that their difficulty is less than starting theta
-  const maxTrialDifficulty = taskStore().startingTheta; 
+  // limit random starting items so that their difficulty is less than 0
+  const maxTrialDifficulty = 0; 
 
   const instructionPracticeTrials: StimulusType[] = corpus.filter(trial => 
     trial.assessmentStage === 'instructions' || trial.assessmentStage === 'practice_response'
@@ -17,7 +17,7 @@ export function prepareCorpus(corpus: StimulusType[]) {
     !isNaN(Number(trial.difficulty)) &&
     !instructionPracticeTrials.includes(trial) &&
     (trial.trialType !== excludedTrialTypes) &&
-    (trial.difficulty <= maxTrialDifficulty)
+    (Number(trial.difficulty) <= maxTrialDifficulty)
   )
   
   const startItems: StimulusType[] = selectNItems(possibleStartItems, 5);

--- a/task-launcher/src/tasks/taskSetup.ts
+++ b/task-launcher/src/tasks/taskSetup.ts
@@ -16,6 +16,7 @@ export const initializeCat = () => {
     method: 'MLE',
     minTheta: -6,
     maxTheta: 6,
+    theta: taskStore().startingTheta || 0,  
     itemSelect: taskStore().itemSelect
   });
 };


### PR DESCRIPTION
This PR adds a url parameter to set the starting theta value, which can be used to start out younger kids with easier items for matrix reasoning and mental rotation. For right now, I also limited the difficulty of the start items so that they are less than the starting theta (otherwise hard items could still show up in the block of 5 random starting items, which I forgot about during the LEVANTE team meeting). 

Another approach could be to create the option to remove the starting items entirely. I'm also not sure if we always want to limit the starting item difficulty - for older kids we might want to allow items that are higher than the starting theta. @mcfrank let me know if you have any thoughts about what to do with the starting block for younger kids. Thanks!