### PR TITLE
Math CAT

### DIFF
--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -114,7 +114,6 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     const fullCorpus = prepareCorpus(corpus); 
 
     const allBlocks: StimulusType[][] = prepareMultiBlockCat(taskStore().corpora.stimulus); 
-    console.log(allBlocks);
 
     const newCorpora = {
       practice: taskStore().corpora.practice,

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -1,10 +1,10 @@
 import 'regenerator-runtime/runtime';
 import store from 'store2';
 // setup
-import { initTrialSaving, initTimeline, createPreloadTrials } from '../shared/helpers';
+import { initTrialSaving, initTimeline, createPreloadTrials, prepareCorpus, prepareMultiBlockCat } from '../shared/helpers';
 import { jsPsych, initializeCat } from '../taskSetup';
 import { slider } from './trials/sliderStimulus';
-import { afcStimulusTemplate, enterFullscreen, exitFullscreen, finishExperiment, getAudioResponse, setupStimulus, taskFinished } from '../shared/trials';
+import { afcStimulusTemplate, enterFullscreen, exitFullscreen, finishExperiment, getAudioResponse, setupStimulus, fixationOnly, setupStimulusFromBlock, taskFinished } from '../shared/trials';
 import { getLayoutConfig } from './helpers/config';
 import { taskStore } from '../../taskStore';
 
@@ -35,6 +35,9 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
   const corpus: StimulusType[] = taskStore().corpora.stimulus;
   const translations: Record<string, string> = taskStore().translations;
   const validationErrorMap: Record<string, string> = {};
+
+  const { runCat } = taskStore(); 
+  const { semThreshold } = taskStore();
 
   const layoutConfigMap: Record<string, LayoutConfigType> = {};
   let i = 0;
@@ -90,7 +93,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       }
       const stim = taskStore().nextStimulus;
       const skipBlockTrialType = store.page.get('skipCurrentBlock');
-      if (stim.trialType === skipBlockTrialType) {
+      if (stim.trialType === skipBlockTrialType && !runCat) {
         return false;
       } else {
         return true;
@@ -98,11 +101,50 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     },
   };
 
-  const numOfTrials = taskStore().totalTrials;
-  for (let i = 0; i < numOfTrials; i++) {
-    timeline.push(setupStimulus);
-    timeline.push(stimulusBlock);
+  if (runCat) {
+    // puts the CAT portion of the corpus into taskStore and removes instructions
+    const fullCorpus = prepareCorpus(corpus); 
+
+    // determines the trial types in each block - this should match indexes/trial types of blocks in corpus
+    const trialTypesByBlock: string[][] = [
+      ["Number Identification", "Number Comparison", "Missing Number", "Number Line 4afc"], 
+      ["Addition", "Subtraction", "Fraction", "Multiplication"], 
+      ["Number Line Slider"]
+    ]
+    const allBlocks: StimulusType[][] = prepareMultiBlockCat(taskStore().corpora.stimulus, trialTypesByBlock); 
+
+    const newCorpora = {
+      practice: taskStore().corpora.practice,
+      stimulus: allBlocks
+    }
+    taskStore('corpora', newCorpora); // puts all blocks into taskStore
+
+    const numOfBlocks = allBlocks.length; 
+    for (let i = 0; i < numOfBlocks; i++) {
+      // push in block-specific instructions 
+      const instructionPractice = fullCorpus.instructionPractice.filter(trial => {
+        return trial.block_index === i.toString();
+      });
+      instructionPractice.forEach((trial) => {
+        timeline.push(fixationOnly);
+        timeline.push(afcStimulusTemplate(trialConfig, trial));
+      });
+
+      const numOfTrials = allBlocks[i].length / 2; // we want to run 50% of the trials in each block
+      for (let j = 0; j < numOfTrials; j++) {
+        timeline.push(setupStimulusFromBlock(i)); // select only from the current block
+        timeline.push(stimulusBlock);
+      }
+    }
+  } else {
+    const numOfTrials = taskStore().totalTrials;
+    for (let i = 0; i < numOfTrials; i++) {
+      timeline.push(setupStimulus);
+      timeline.push(stimulusBlock);
+    }
   }
+
+  
 
   initializeCat();
 

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -39,7 +39,6 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
   const validationErrorMap: Record<string, string> = {};
 
   const { runCat } = taskStore(); 
-  const { semThreshold } = taskStore();
 
   const layoutConfigMap: Record<string, LayoutConfigType> = {};
   let i = 0;

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -8,12 +8,17 @@ import { cat, jsPsych } from '../../taskSetup';
 // the next item, stores it in a session variable, and removes it from the corpus
 // corpusType is the name of the subTask's corpus within corpusLetterAll[]
 
-export const getStimulus = (corpusType: string) => {
+export const getStimulus = (corpusType: string, blockNumber?: number) => {
   let corpus, itemSuggestion;
 
   corpus = taskStore().corpora;
+  console.log("Block number:\n");
+  console.log(blockNumber);
 
-  itemSuggestion = cat.findNextItem(corpus[corpusType]);
+  // if block number is specified, get next item from only the indicated block of the corpus
+  blockNumber != undefined ? 
+    itemSuggestion = cat.findNextItem(corpus[corpusType][blockNumber]) : 
+    itemSuggestion = cat.findNextItem(corpus[corpusType])
 
   const stimAudio = itemSuggestion.nextStimulus.audioFile;
   if (stimAudio && !mediaAssets.audio[camelize(stimAudio)]) {
@@ -27,6 +32,9 @@ export const getStimulus = (corpusType: string) => {
   taskStore('nextStimulus', itemSuggestion.nextStimulus);
 
   // update the corpus with the remaining unused items
-  corpus[corpusType] = itemSuggestion.remainingStimuli;
+  blockNumber != undefined ? 
+    corpus[corpusType][blockNumber] = itemSuggestion.remainingStimuli :
+    corpus[corpusType] = itemSuggestion.remainingStimuli
+
   taskStore('corpora', corpus);
 };

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -12,8 +12,6 @@ export const getStimulus = (corpusType: string, blockNumber?: number) => {
   let corpus, itemSuggestion;
 
   corpus = taskStore().corpora;
-  console.log("Block number:\n");
-  console.log(blockNumber);
 
   // if block number is specified, get next item from only the indicated block of the corpus
   blockNumber != undefined ? 

--- a/task-launcher/src/tasks/shared/helpers/index.ts
+++ b/task-launcher/src/tasks/shared/helpers/index.ts
@@ -24,7 +24,7 @@ export * from './setSkipCurrentBlock'
 export { PageAudioHandler } from './audioHandler';
 export { PageStateHandler } from './PageStateHandler';
 export { camelize } from './camelize';
-export * from './prepareCat';
+export { updateTheta, prepareCorpus, prepareMultiBlockCat, selectNItems} from './prepareCat';
 export { convertItemToString } from './convertItemToString';
 export { validateLayoutConfig } from './validateLayoutConfig';
 export { mapDistractorsToString } from './mapDistractorsToString';

--- a/task-launcher/src/tasks/shared/helpers/index.ts
+++ b/task-launcher/src/tasks/shared/helpers/index.ts
@@ -24,7 +24,7 @@ export * from './setSkipCurrentBlock'
 export { PageAudioHandler } from './audioHandler';
 export { PageStateHandler } from './PageStateHandler';
 export { camelize } from './camelize';
-export { prepareCorpus, selectNItems } from './prepareCat';
+export { prepareCorpus, selectNItems, prepareMultiBlockCat } from './prepareCat';
 export { convertItemToString } from './convertItemToString';
 export { validateLayoutConfig } from './validateLayoutConfig';
 export { mapDistractorsToString } from './mapDistractorsToString';

--- a/task-launcher/src/tasks/shared/helpers/index.ts
+++ b/task-launcher/src/tasks/shared/helpers/index.ts
@@ -24,7 +24,7 @@ export * from './setSkipCurrentBlock'
 export { PageAudioHandler } from './audioHandler';
 export { PageStateHandler } from './PageStateHandler';
 export { camelize } from './camelize';
-export { prepareCorpus, selectNItems, prepareMultiBlockCat } from './prepareCat';
+export * from './prepareCat';
 export { convertItemToString } from './convertItemToString';
 export { validateLayoutConfig } from './validateLayoutConfig';
 export { mapDistractorsToString } from './mapDistractorsToString';

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -63,3 +63,16 @@ export function selectNItems(corpus: StimulusType[], n: number) {
 
   return finalTrials; 
 }
+
+// separates cat corpus into blocks of trials of a certain type (or list of types)
+export function prepareMultiBlockCat(corpus: StimulusType[], trialTypes: string[][]) {
+  const blockList: StimulusType[][] = []; // a list of blocks, each containing trials
+
+  trialTypes.forEach((trialList: string[]) => {
+    blockList.push(corpus.filter(trial => 
+      trialList.includes(trial.trialType)
+    ));
+  });
+
+  return blockList; 
+}

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -99,7 +99,6 @@ export function updateTheta(item: StimulusType, correct: boolean) {
         if (!(Number.isNaN(zeta.b)) && (item.assessmentStage !== 'practice_response')) {
           const answer = correct ? 1 : 0;
           cat.updateAbilityEstimate(zeta, answer); 
-          console.log(cat.theta);
         }
       }
 }

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -342,6 +342,8 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
   startTime = performance.now();
 
   const stim = trial || taskStore().nextStimulus as StimulusType;
+  console.log("Item difficulty:\n");
+  console.log(stim.difficulty);
   const itemLayoutConfig = layoutConfigMap?.[stim.itemId];
   const playAudioOnLoad = itemLayoutConfig?.playAudioOnLoad;
   const pageStateHandler = new PageStateHandler(stim.audioFile, playAudioOnLoad);

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -1,7 +1,7 @@
 // For all tasks except: H&F, Memory Game, Same Different Selection
 import jsPsychHtmlMultiResponse from '@jspsych-contrib/plugin-html-multi-response';
 import _toNumber from 'lodash/toNumber';
-import { jsPsych, isTouchScreen, cat } from '../../taskSetup';
+import { jsPsych, isTouchScreen } from '../../taskSetup';
 import {
   arrowKeyEmojis,
   replayButtonSvg,
@@ -11,6 +11,7 @@ import {
   PageStateHandler,
   camelize,
   setSentryContext,
+  updateTheta
 } from '../helpers';
 import { mediaAssets } from '../../..';
 import { finishExperiment } from '.';
@@ -342,8 +343,6 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
   startTime = performance.now();
 
   const stim = trial || taskStore().nextStimulus as StimulusType;
-  console.log("Item difficulty:\n");
-  console.log(stim.difficulty);
   const itemLayoutConfig = layoutConfigMap?.[stim.itemId];
   const playAudioOnLoad = itemLayoutConfig?.playAudioOnLoad;
   const pageStateHandler = new PageStateHandler(stim.audioFile, playAudioOnLoad);
@@ -462,18 +461,7 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
     }
     
     if (runCat) {
-    // update theta for CAT
-      const zeta = {
-        a: 1, // item discrimination (default value of 1)
-        b: stimulus.difficulty, // item difficulty (from corpus)
-        c: stimulus.chanceLevel, // probability of correct answer from guessing
-        d: 1 // max probability of correct response (default 1)
-      }; 
-    
-      if (!(Number.isNaN(zeta.b)) && (stimulus.assessmentStage !== 'practice_response')) {
-        const answer = data.correct ? 1 : 0;
-        cat.updateAbilityEstimate(zeta, answer)
-      }
+      updateTheta(stimulus, data.correct); 
     }
 
     // check response and record it

--- a/task-launcher/src/tasks/shared/trials/setup.ts
+++ b/task-launcher/src/tasks/shared/trials/setup.ts
@@ -4,23 +4,8 @@ import { getStimulus } from '../helpers';
 // choosing the next stimulus from the corpus occurs during the fixation trial
 // prior to the actual display of the stimulus, where user response is collected
 // the array allows us to use the same structure for all corpuses
-const setupData = [
-  {
-    onFinish: () => {
-      getStimulus('practice');
-    },
-  },
-  {
-    onFinish: () => {
-      getStimulus('stimulus');
-    },
-  },
-  {
-    onFinish: () => {}
-  }
-];
 
-const setupTrials = setupData.map((trial) => {
+const fixationTrial = (corpusType?: string, blockNum?: number) => {
   return {
     type: jsPsychHTMLMultiResponse,
     stimulus: `<div id='lev-fixation-container'><p>+</p></div>`,
@@ -30,10 +15,20 @@ const setupTrials = setupData.map((trial) => {
     data: {
       task: 'fixation',
     },
-    on_finish: trial.onFinish,
+    on_finish: () => {
+      if (corpusType) {
+        if (blockNum != undefined) {
+          getStimulus(corpusType, blockNum);
+        } else {
+          getStimulus(corpusType); 
+        }
+      }
+    },
   };
-});
+};
 
-export const setupPractice = setupTrials[0];
-export const setupStimulus = setupTrials[1];
-export const fixationOnly = setupTrials[2]; 
+export const setupPractice = fixationTrial("practice");
+export const setupStimulus = fixationTrial("stimulus");
+export const setupStimulusFromBlock = (blockNum: number) => fixationTrial("stimulus", blockNum);
+export const fixationOnly = fixationTrial(); 
+


### PR DESCRIPTION
This PR implements an adaptive version of math with 3 blocks. The CAT currently runs 50% of the trials in the corpus from each block before advancing to the next block, carrying over a single theta estimate between blocks. The first block starts with 5 random items restricted to only trials from that block.  Any practice and instruction trials in the corpus are added to the beginning of their respective block. 