### PR TITLE
Fix scoring of higher-dimension matching trials in same different selection

### DIFF
--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -220,8 +220,8 @@ export const afcMatch = {
           previousSelections.forEach((item: string[]) => {
             // check that most recent selection does not have the same cards as a previous selection (even in reverse)
             if (
-              selections[0] == item[0] && selections[1] == item[1] ||
-              selections[1] == item[0] && selections[0] == item[1]
+              selections[0] === item[0] && selections[1] === item[1] ||
+              selections[1] === item[0] && selections[0] === item[1]
             ) {
               hasNewSelection = false; 
             }

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -7,7 +7,7 @@ import { taskStore } from '../../../taskStore';
 
 let selectedCards: string[] = [];
 let selectedCardIdxs: number[] = [];
-let previousSelections: string[] = [];
+let previousSelections: string[][] = [];
 let startTime: number; 
 
 const replayButtonHtmlId = 'replay-btn-revisited';
@@ -158,11 +158,24 @@ export const afcMatch = {
       previousSelections = [];
     }
 
+    function cleanAttributes(attributes: string[]) {
+      const nonWhiteBackgrounds: string[] = ["gray", "striped", "black"]; 
+      // add in the background string if it's not there (white background)
+      if (!attributes.some((item) => nonWhiteBackgrounds.includes(item))) {
+        attributes.push("white");
+      } 
+      if (!attributes.some((item) => !isNaN(Number(item)))) {
+        attributes.splice(3, 0, "1"); 
+      }
+
+      return attributes; 
+    }
+
     // First check amongst the selections if they all share one trait
     // Second check if any previous selections used those EXACT same selections
     // At least one selection must be different from previous selections
     // (also, ignore any specified dimension -- some blocks now don't vary particular dimensions)
-    function compareSelections(selections: string[], previousSelections: string[], ignoreDims: string[]) {
+    function compareSelections(selections: string[], previousSelections: string[][], ignoreDims: string[]) {
       const dimensionIndices = {
           size: 0,
           color: 1,
@@ -184,7 +197,7 @@ export const afcMatch = {
   
           // Populate sets with values from selections
           for (const sel of selections) {
-              const attributes = sel.split("-");
+              const attributes = cleanAttributes(sel.split("-"));
               for (const [dim, set] of Object.entries(sets)) {
                   const index = dimensionIndices[dim as keyof typeof dimensionIndices];
                   if (attributes[index] !== undefined) {
@@ -192,20 +205,30 @@ export const afcMatch = {
                   }
               }
           }
-  
           // Check if any non-ignored dimension has all the same values
           return Object.values(sets).some(set => set.size === 1);
       }
   
       // Check if any selection is different from all previous selections
-      function hasNewSelection(selections: string[], previousSelections: string[]) {
+      function hasNewSelection(selections: string[], previousSelections: string[][]) {
           // If there are no previous selections, every current selection is considered new
           if (!previousSelections || previousSelections.length === 0) {
               return true;
           }
+
+          let hasNewSelection = true; 
+          previousSelections.forEach((item: string[]) => {
+            // check that most recent selection does not have the same cards as a previous selection (even in reverse)
+            if (
+              selections[0] == item[0] && selections[1] == item[1] ||
+              selections[1] == item[0] && selections[0] == item[1]
+            ) {
+              hasNewSelection = false; 
+            }
+          })
+
   
-          const allPrevious = new Set(previousSelections);
-          return selections.some(sel => !allPrevious.has(sel));
+          return hasNewSelection;
       }
   
       // Perform checks
@@ -237,7 +260,7 @@ export const afcMatch = {
     jsPsych.data.addDataToLastTrial({
       correct: isCorrect,
     });
-    previousSelections.push(...selectedCards);
+    previousSelections.push(selectedCards);
     selectedCards = [];
     selectedCardIdxs = [];
 


### PR DESCRIPTION
This PR fixes the way that higher-dimension matching trials are scored. Because the item names in the corpus leave out the number or color dimension if it has the default value (for example,  "med-red-square" rather than "med-red-square-1-white") I added those values back in the task code before they are scored. Additionally, a selection is now flagged as a repeat only if the same two cards were picked in one previous selection (rather than across multiple previous selections). 