### PR TITLE
Add practice trials to math and shorten gap between blocks

### DIFF
--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -32,8 +32,10 @@ import store from 'store2';
  * ------- AFC only -------
  * @property {boolean} skipCurrentTrial - Whether to skip the current trial, default is false.
  * @property {number} correctResponseIdx - Index of the correct response, starting at 0.
+ * @property {number} incorrectPracticeResponses - Number of incorrect responses to the current practice trial. 
  * ------- Math only -------
  * @property {Array} nonFractionSelections - List of non-fraction selections.
+ * @property {number} trialsSkipped - Number of trials that have been skipped while jumping to the next block.
  * ------- H&F only -------
  * @property {string} stimulus - Name of the stimulus, default is 'heart'.
  * @property {string} stimulusSide - Side of the stimulus, default is 'left'.

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -240,6 +240,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     taskStore('corpora', newCorpora); // puts all blocks into taskStore
 
     const numOfBlocks = allBlocks.length; 
+    const trialProportionsPerBlock = [2, 3, 3]; // divide by these numbers to get trials per block
     for (let i = 0; i < numOfBlocks; i++) {
       // push in block-specific instructions 
       const blockInstructions = instructions.filter(trial => {
@@ -278,7 +279,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
         );
       }
 
-      const numOfTrials = allBlocks[i].length / 2; // we want to run 50% of the trials in each block
+      const numOfTrials = (allBlocks[i].length / trialProportionsPerBlock[i]); 
       for (let j = 0; j < numOfTrials; j++) {
         timeline.push({...setupStimulusFromBlock(i), stimulus: ''}); // select only from the current block
         timeline.push(stimulusBlock());

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -7,7 +7,6 @@ import {
   createPreloadTrials, 
   prepareCorpus, 
   prepareMultiBlockCat, 
-  getStimulus 
 } from '../shared/helpers';
 import { jsPsych, initializeCat } from '../taskSetup';
 import { slider } from './trials/sliderStimulus';
@@ -22,7 +21,7 @@ import {
   setupStimulusFromBlock, 
   taskFinished, 
   practiceTransition, 
-  feedback
+  feedback,
 } from '../shared/trials';
 import { getLayoutConfig } from './helpers/config';
 import { taskStore } from '../../taskStore';
@@ -107,10 +106,10 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       {...setupStimulus, stimulus: ''}
     ], 
     conditional_function: () => {
-      const trialsSkipped = store.page.get("trialsSkipped");
+      const trialsSkipped = taskStore().trialsSkipped;
 
       if (trialsSkipped > 0) {
-        store.page.transact('trialsSkipped', (oldVal: number) => oldVal - 1); 
+        taskStore("trialsSkipped", (trialsSkipped -1)); 
         return false;
       } else {
         return true;
@@ -123,7 +122,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       {...fixationOnly, stimulus: ''}
     ], 
     conditional_function: () => {
-      return (store.page.get('trialsSkipped') === 1);
+      return (taskStore().trialsSkipped === 1);
     }
   }
 
@@ -133,7 +132,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
         afcStimulusTemplate(trialConfig, trial),
       ],
       conditional_function: () => {
-        const trialsSkipped = store.page.get("trialsSkipped");
+        const trialsSkipped = taskStore().trialsSkipped;
         if (trialsSkipped > 0) {
           return false; 
         }
@@ -146,11 +145,11 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
   const sliderBlock = (trial?: StimulusType) => {
     return {
       timeline: [
-        slider(trial), 
+        slider(layoutConfigMap, trial), 
         feedbackBlock(trial)
       ],
       conditional_function: () => {
-        const trialsSkipped = store.page.get("trialsSkipped");
+        const trialsSkipped = taskStore().trialsSkipped;
         
         if (trialsSkipped > 0) {
           return false; 
@@ -169,7 +168,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
   const repeatSliderPracticeBlock = () => {
     let trials: any[] = []; 
     sliderPractice.forEach((trial, index) => {
-      trials.push(slider(trial)); 
+      trials.push(slider(layoutConfigMap, trial)); 
       if (index < sliderPractice.length - 1) {
         trials.push(
           {

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -119,7 +119,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
 
   const interBlockGap = {
     timeline: [
-      {...fixationOnly, stimulus: ''}
+      {...fixationOnly, stimulus: '', post_trial_gap: 350}
     ], 
     conditional_function: () => {
       return (taskStore().trialsSkipped === 1);

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -14,7 +14,8 @@ import {
   fixationOnly, 
   setupStimulusFromBlock, 
   taskFinished, 
-  practiceTransition
+  practiceTransition, 
+  feedback
 } from '../shared/trials';
 import { getLayoutConfig } from './helpers/config';
 import { taskStore } from '../../taskStore';
@@ -76,6 +77,24 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     layoutConfigMap,
   };
 
+  const feedbackBlock = (trial?: StimulusType) => {
+    return {
+      timeline: [
+        feedback(true, 'feedbackCorrect', 'feedbackTryAgain')
+      ], 
+      conditional_function: () => {
+        if (!trial) {
+          return (
+            taskStore().nextStimulus.assessmentStage === "practice_response" && 
+            taskStore().nextStimulus.trialType === "Number Line Slider"
+          )
+        } else {
+          return trial.trialType === "Number Line Slider";
+        }
+      }
+    }
+  }
+
   const afcStimulusBlock = (trial?: StimulusType) => {
     return {
       timeline: [
@@ -89,12 +108,50 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
 
   const sliderBlock = (trial?: StimulusType) => {
     return {
-      timeline: [slider(trial)],
+      timeline: [
+        slider(trial), 
+        feedbackBlock(trial)
+      ],
       conditional_function: () => {
         return (trial || taskStore().nextStimulus).trialType?.includes('Number Line');
       },
     }
   };
+
+  const sliderPractice: StimulusType[] = corpus.filter((trial) => {
+    return (trial.trialType === "Number Line Slider") && (trial.assessmentStage === "practice_response")
+  });
+
+  // this block repeats all slider practice trials
+  const repeatSliderPracticeBlock = () => {
+    let trials: any[] = []; 
+    sliderPractice.forEach((trial, index) => {
+      trials.push(slider(trial)); 
+      if (index < sliderPractice.length - 1) {
+        trials.push(
+          {
+            ...feedback(true, 'feedbackCorrect', 'feedbackTryAgain'), 
+            conditional_function: () => {return true}, 
+            post_trial_gap: 350
+          } 
+        );
+      }
+    })
+
+    return {
+      timeline: [ 
+        ...trials
+      ], 
+      conditional_function: () => {
+        return (
+          !taskStore().isCorrect &&
+          taskStore().testPhase === false && 
+          (taskStore().nextStimulus.trialType === "Number Line Slider" || runCat) &&
+          taskStore().nextStimulus.assessmentStage === "test_response"
+        );  
+      }
+    }
+  }
 
   const stimulusBlock = (trial?: StimulusType) => {
     return {
@@ -156,8 +213,17 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       });
       blockPractice.forEach((trial) => {
         timeline.push({...fixationOnly, stimulus: ''});
-        timeline.push(afcStimulusTemplate(trialConfig, trial));
+        timeline.push(stimulusBlock(trial));
+        
+        if (trial.trialType === "Number Line Slider") {
+          timeline.push(feedbackBlock()); 
+        }
       });
+
+      // final slider block
+      if (i === 2) {
+        timeline.push(repeatSliderPracticeBlock());
+      }
 
       // practice transition screen
       timeline.push(practiceTransition);
@@ -195,6 +261,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     const numOfTrials = taskStore().totalTrials;
     for (let i = 0; i < numOfTrials; i++) {
       timeline.push({...setupStimulus, stimulus: ''});
+      timeline.push(repeatSliderPracticeBlock());
       timeline.push(practiceTransition); 
       timeline.push(stimulusBlock());
     }

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -333,7 +333,9 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
       });
     }
   
-    setSkipCurrentBlock(stimulus.trialType);
+    if (!runCat) {
+      setSkipCurrentBlock(stimulus.trialType);
+    }
   },
   }
 };

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -1,20 +1,41 @@
 import { mediaAssets } from "../../..";
 import { jsPsych } from "../../taskSetup";
 import { PageAudioHandler } from "./audioHandler";
+import { taskStore } from "../../../taskStore";
 
 function enableBtns(btnElements: NodeListOf<HTMLButtonElement>) {
     btnElements.forEach((btn) => (btn.disabled = false));
 }
 
-export function handlePracticeButtonPress(
+export function addPracticeButtonListeners(stim: StimulusType, isTouchScreen: boolean, itemConfig: LayoutConfigType) {
+  const practiceBtns: NodeListOf<HTMLButtonElement> = document.querySelectorAll('.practice-btn');
+  let keyboardFeedbackHandler: (ev: KeyboardEvent) => void;
+    
+  practiceBtns.forEach((btn, i) =>
+    btn.addEventListener('click', async (e) => {
+      handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
+    }),
+  );
+    
+  if (!isTouchScreen) {
+    keyboardFeedbackHandler = (e: KeyboardEvent) => keyboardBtnFeedback(e, practiceBtns, stim, itemConfig);
+    document.addEventListener('keydown', keyboardFeedbackHandler);
+
+    return keyboardFeedbackHandler; 
+  }
+}
+
+function handlePracticeButtonPress(
   btn: HTMLButtonElement,
   stim: StimulusType,
   practiceBtns: NodeListOf<HTMLButtonElement>,
   isKeyBoardResponse: boolean,
   responsevalue: string | number,
-  incorrectPracticeResponses: Array<string | null> = []
+  itemConfig: LayoutConfigType,
 ) {
-  const choice = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+  const index = Array.prototype.indexOf.call(practiceBtns, btn);
+  const choices = itemConfig.response?.values || [];
+  const choice = choices[index];
   const isCorrectChoice = choice?.toString() === stim.answer?.toString();
   let feedbackAudio;
 
@@ -24,7 +45,7 @@ export function handlePracticeButtonPress(
     setTimeout(
       () => jsPsych.finishTrial({
         response: choice,
-        incorrectPracticeResponses, 
+        incorrectPracticeResponses: taskStore().incorrectPracticeResponses, 
         button_response: !isKeyBoardResponse ? responsevalue : null,
         keyboard_response: isKeyBoardResponse ? responsevalue : null,
       }),
@@ -35,46 +56,47 @@ export function handlePracticeButtonPress(
     feedbackAudio = mediaAssets.audio.feedbackTryAgain;
     // jspysch disables the buttons for some reason, so re-enable them
     setTimeout(() => enableBtns(practiceBtns), 500);
+
+    let incorrectPracticeResponses = taskStore().incorrectPracticeResponses; 
     incorrectPracticeResponses.push(choice);
+    taskStore("incorrectPracticeResponses", incorrectPracticeResponses);
   }
   // if there is audio playing, stop it first before playing feedback audio to prevent overlap between trials
   PageAudioHandler.stopAndDisconnectNode();
   PageAudioHandler.playAudio(feedbackAudio);
-
-  return incorrectPracticeResponses; 
 }
 
-export const getKeyboardChoices = (buttonLength: number) => {
-    if (buttonLength === 1) { // instruction trial
-      return ['Enter'];
-    }
-    if (buttonLength === 2) {
-      return ['ArrowLeft', 'ArrowRight'];
-    }
-    if (buttonLength === 3) {
-      return ['ArrowUp', 'ArrowLeft', 'ArrowRight'];
-    }
-    if (buttonLength === 4) {
-      return ['ArrowUp', 'ArrowLeft', 'ArrowRight', 'ArrowDown'];
-    }
-    throw new Error('More than 4 buttons are not supported yet');
-  };
+const getKeyboardChoices = (itemConfig: LayoutConfigType) => {
+  const buttonLength = itemConfig.response.values.length;
+  if (buttonLength === 1) { // instruction trial
+    return ['Enter'];
+  }
+  if (buttonLength === 2) {
+    return ['ArrowLeft', 'ArrowRight'];
+  }
+  if (buttonLength === 3) {
+    return ['ArrowUp', 'ArrowLeft', 'ArrowRight'];
+  }
+  if (buttonLength === 4) {
+    return ['ArrowUp', 'ArrowLeft', 'ArrowRight', 'ArrowDown'];
+  }
+  throw new Error('More than 4 buttons are not supported yet');
+};
 
-export async function keyboardBtnFeedback(e: KeyboardEvent, practiceBtns: NodeListOf<HTMLButtonElement>, stim: StimulusType) {
-    const allowedKeys = getKeyboardChoices(practiceBtns.length);
+async function keyboardBtnFeedback(
+  e: KeyboardEvent, practiceBtns: 
+  NodeListOf<HTMLButtonElement>, 
+  stim: StimulusType, 
+  itemConfig: LayoutConfigType,
+) {
+    const allowedKeys = getKeyboardChoices(itemConfig);
     const index = allowedKeys.findIndex(f => f.toLowerCase() === e.key.toLowerCase())
   
     if (allowedKeys.includes(e.key)) {
-      const btn = practiceBtns[index]; 
-      const choice = btn.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
-      
-      const btnClicked = Array.from(practiceBtns).find(btn => {
-        const btnOption = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
-        return (btnOption || '').toString() === (choice || '')?.toString();
-      });
+      const btnClicked = practiceBtns[index];
 
       if (btnClicked) {
-        handlePracticeButtonPress(btnClicked, stim, practiceBtns, true, e.key.toLowerCase());
+        handlePracticeButtonPress(btnClicked, stim, practiceBtns, true, e.key.toLowerCase(), itemConfig);
       }
     }
-  }
+}

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -1,0 +1,80 @@
+import { mediaAssets } from "../../..";
+import { jsPsych } from "../../taskSetup";
+import { PageAudioHandler } from "./audioHandler";
+
+function enableBtns(btnElements: NodeListOf<HTMLButtonElement>) {
+    btnElements.forEach((btn) => (btn.disabled = false));
+}
+
+export function handlePracticeButtonPress(
+  btn: HTMLButtonElement,
+  stim: StimulusType,
+  practiceBtns: NodeListOf<HTMLButtonElement>,
+  isKeyBoardResponse: boolean,
+  responsevalue: string | number,
+  incorrectPracticeResponses: Array<string | null> = []
+) {
+  const choice = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+  const isCorrectChoice = choice?.toString() === stim.answer?.toString();
+  let feedbackAudio;
+
+  if (isCorrectChoice) {
+    btn.classList.add('success-shadow');
+    feedbackAudio = mediaAssets.audio.feedbackGoodJob;
+    setTimeout(
+      () => jsPsych.finishTrial({
+        response: choice,
+        incorrectPracticeResponses, 
+        button_response: !isKeyBoardResponse ? responsevalue : null,
+        keyboard_response: isKeyBoardResponse ? responsevalue : null,
+      }),
+      1000,
+    );
+  } else {
+    btn.classList.add('error-shadow');
+    feedbackAudio = mediaAssets.audio.feedbackTryAgain;
+    // jspysch disables the buttons for some reason, so re-enable them
+    setTimeout(() => enableBtns(practiceBtns), 500);
+    incorrectPracticeResponses.push(choice);
+  }
+  // if there is audio playing, stop it first before playing feedback audio to prevent overlap between trials
+  PageAudioHandler.stopAndDisconnectNode();
+  PageAudioHandler.playAudio(feedbackAudio);
+
+  return incorrectPracticeResponses; 
+}
+
+export const getKeyboardChoices = (buttonLength: number) => {
+    if (buttonLength === 1) { // instruction trial
+      return ['Enter'];
+    }
+    if (buttonLength === 2) {
+      return ['ArrowLeft', 'ArrowRight'];
+    }
+    if (buttonLength === 3) {
+      return ['ArrowUp', 'ArrowLeft', 'ArrowRight'];
+    }
+    if (buttonLength === 4) {
+      return ['ArrowUp', 'ArrowLeft', 'ArrowRight', 'ArrowDown'];
+    }
+    throw new Error('More than 4 buttons are not supported yet');
+  };
+
+export async function keyboardBtnFeedback(e: KeyboardEvent, practiceBtns: NodeListOf<HTMLButtonElement>, stim: StimulusType) {
+    const allowedKeys = getKeyboardChoices(practiceBtns.length);
+    const index = allowedKeys.findIndex(f => f.toLowerCase() === e.key.toLowerCase())
+  
+    if (allowedKeys.includes(e.key)) {
+      const btn = practiceBtns[index]; 
+      const choice = btn.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+      
+      const btnClicked = Array.from(practiceBtns).find(btn => {
+        const btnOption = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+        return (btnOption || '').toString() === (choice || '')?.toString();
+      });
+
+      if (btnClicked) {
+        handlePracticeButtonPress(btnClicked, stim, practiceBtns, true, e.key.toLowerCase());
+      }
+    }
+  }

--- a/task-launcher/src/tasks/shared/helpers/index.ts
+++ b/task-launcher/src/tasks/shared/helpers/index.ts
@@ -30,4 +30,4 @@ export { validateLayoutConfig } from './validateLayoutConfig';
 export { mapDistractorsToString } from './mapDistractorsToString';
 export { setSentryContext } from './setSentryContext';
 export { handleStaggeredButtons } from './staggerButtons';
-export { handlePracticeButtonPress, keyboardBtnFeedback, getKeyboardChoices } from './handlePracticeButtons';
+export { addPracticeButtonListeners } from './handlePracticeButtons';

--- a/task-launcher/src/tasks/shared/helpers/index.ts
+++ b/task-launcher/src/tasks/shared/helpers/index.ts
@@ -30,3 +30,4 @@ export { validateLayoutConfig } from './validateLayoutConfig';
 export { mapDistractorsToString } from './mapDistractorsToString';
 export { setSentryContext } from './setSentryContext';
 export { handleStaggeredButtons } from './staggerButtons';
+export { handlePracticeButtonPress, keyboardBtnFeedback, getKeyboardChoices } from './handlePracticeButtons';

--- a/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
+++ b/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
@@ -4,11 +4,12 @@ import { getStimulus } from './getStimulus';
 
 function skipBlock() {
     const skipBlockTrialType = store.page.get('skipCurrentBlock');
-    store.page.set('trialsSkipped', 0); 
+    taskStore('trialsSkipped', 0); 
     while (taskStore().nextStimulus.trialType === skipBlockTrialType) {
-      getStimulus("stimulus"); 
-      taskStore().nextStimulus.trialType; 
-      store.page.transact('trialsSkipped', (oldVal: number) => oldVal + 1); 
+      getStimulus("stimulus");
+      
+      const trialsSkipped = taskStore().trialsSkipped;
+      taskStore("trialsSkipped", (trialsSkipped + 1));
     }
   }
 

--- a/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
+++ b/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
@@ -6,6 +6,11 @@ function skipBlock() {
     const skipBlockTrialType = store.page.get('skipCurrentBlock');
     taskStore('trialsSkipped', 0); 
     while (taskStore().nextStimulus.trialType === skipBlockTrialType) {
+      // do not call getStimulus if there are no remaining stimuli
+      if (taskStore().corpora.stimulus.length === 0) {
+        break;
+      }
+
       getStimulus("stimulus");
       
       const trialsSkipped = taskStore().trialsSkipped;

--- a/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
+++ b/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
@@ -1,13 +1,26 @@
 import store from 'store2';
 import { taskStore } from '../../../taskStore';
+import { getStimulus } from './getStimulus';
+
+function skipBlock() {
+    const skipBlockTrialType = store.page.get('skipCurrentBlock');
+    store.page.set('trialsSkipped', 0); 
+    while (taskStore().nextStimulus.trialType === skipBlockTrialType) {
+      getStimulus("stimulus"); 
+      taskStore().nextStimulus.trialType; 
+      store.page.transact('trialsSkipped', (oldVal: number) => oldVal + 1); 
+    }
+  }
 
 export const setSkipCurrentBlock = (skipTrialType: string) => {
   if (!!store.page.get('failedPrimaryTrials') && taskStore().numIncorrect >= 1) {
     taskStore('numIncorrect', 0);
     store.page.set('skipCurrentBlock', skipTrialType);
+    skipBlock();
   } else if ((taskStore().numIncorrect >= taskStore().maxIncorrect)) {
     taskStore('numIncorrect', 0);
     store.page.set('skipCurrentBlock', skipTrialType);
     store.page.set('failedPrimaryTrials', true);
+    skipBlock();
   }
 };

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -216,7 +216,18 @@ function handlePracticeButtonPress(
   isKeyBoardResponse: boolean,
   responsevalue: string | number,
 ) {
-  const choice = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+  let choice; 
+  if (stim.trialType.includes("Fraction")) {
+    // get the numbers nested inside the button in the DOM
+    const numerator = [0, 0, 0, 0, 0].reduce((el: any, index) => el.children[index], btn).textContent; 
+    const denominator = [0, 0, 0, 1, 0].reduce((el: any, index) => el.children[index], btn).textContent;
+
+    choice = numerator + "/" + denominator; 
+
+  } else {
+    choice = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+  }
+
   const isCorrectChoice = choice?.toString() === stim.answer?.toString();
   let feedbackAudio;
   if (isCorrectChoice) {
@@ -251,7 +262,18 @@ async function keyboardBtnFeedback(e: KeyboardEvent, practiceBtns: NodeListOf<HT
   if (allowedKeys.includes(e.key)) {
     const choice = choices[index];
     const btnClicked = Array.from(practiceBtns).find(btn => {
-      const btnOption = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+      let btnOption; 
+      if (stim.trialType.includes("Fraction")) {
+        // get the numbers nested inside the button in the DOM
+        const numerator = [0, 0, 0, 0, 0].reduce((el: any, index) => el.children[index], btn).textContent; 
+        const denominator = [0, 0, 0, 1, 0].reduce((el: any, index) => el.children[index], btn).textContent;
+
+        btnOption = numerator + "/" + denominator; 
+
+      } else {
+        btnOption = btn?.children?.length ? (btn.children[0] as HTMLImageElement).alt : btn.textContent;
+      }
+      
       return (btnOption || '').toString() === (choice || '')?.toString();
     });
     if (btnClicked) {

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -428,7 +428,7 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
     audioButtonPresses: PageAudioHandler.replayPresses
   });
 
-  if (itemLayoutConfig.inCorrectTrialConfig.onIncorrectTrial === 'skip') {
+  if (itemLayoutConfig.inCorrectTrialConfig.onIncorrectTrial === 'skip' && !runCat) {
     setSkipCurrentBlock(stimulus.trialType);
   } else if ((taskStore().numIncorrect >= taskStore().maxIncorrect && !runCat)) {
     finishExperiment();

--- a/task-launcher/src/tasks/shared/trials/feedback.ts
+++ b/task-launcher/src/tasks/shared/trials/feedback.ts
@@ -28,7 +28,10 @@ export const feedback = (isPractice = false, correctFeedbackAudioKey: string, in
                                 promptOnIncorrect = t.memoryGameForwardPrompt;
                             }
                             break; 
-                        default: 
+                        case 'egma-math':
+                            promptOnIncorrect = t.numberLineSliderPrompt1; 
+                            break;
+                        default:
                             promptOnIncorrect = '';
                     }
 


### PR DESCRIPTION
This PR allows practice trials to be added to the slider block, which currently repeat once as a block if they are answered incorrectly. It also prevents the pause that occurs when the task skips to the next block. 