### PR TITLE
Update math feedback and instructions

### DIFF
--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -23,7 +23,7 @@ export const getLayoutConfig = (
   const stimItem = convertItemToString(stimulus.item);
   defaultConfig.isPracticeTrial = stimulus.assessmentStage === 'practice_response';
   defaultConfig.isInstructionTrial = stimulus.trialType === 'instructions';
-  defaultConfig.showStimImage = false;
+  defaultConfig.showStimImage = stimulus.trialType === "instructions";
   defaultConfig.stimText = {
     value: stimItem,
     displayValue: undefined,
@@ -51,6 +51,7 @@ export const getLayoutConfig = (
     }
   } else {
     defaultConfig.classOverrides.buttonClassList = ['primary'];
+    defaultConfig.classOverrides.stimulusContainerClassList = ['lev-row-container'];
   }
 
   const messages = validateLayoutConfig(defaultConfig, mediaAssets, translations, stimulus)

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -248,9 +248,33 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     const trialProportionsPerBlock = [2, 3, 3]; // divide by these numbers to get trials per block
     for (let i = 0; i < numOfBlocks; i++) {
       // push in block-specific instructions 
+      let usedIDs: string[] = []; 
       const blockInstructions = instructions.filter(trial => {
-        return trial.block_index === i.toString();
+        let allowedIDs: string[]; // CAT only uses particular instructions from corpus
+
+        switch(i) {
+          case 0:
+            allowedIDs = ["math-instructions1", "math-intro1"];
+            break;
+          case 1:
+            allowedIDs = ["math-intro2"];
+            break;
+          case 2:
+            allowedIDs = ["math-intro2", "number-line-instruct1"];
+            break;
+          default:
+            allowedIDs = [];
+        }
+
+        const include = trial.block_index === i.toString() && allowedIDs.includes(trial.itemId) && !(usedIDs.includes(trial.itemId));
+
+        if (include) {
+          usedIDs.push(trial.itemId);
+        }
+         
+        return include; 
       });
+
       blockInstructions.forEach((trial) => {
         timeline.push({...fixationOnly, stimulus: ''});
         timeline.push(afcStimulusTemplate(trialConfig, trial));

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -92,7 +92,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
   const feedbackBlock = (trial?: StimulusType) => {
     return {
       timeline: [
-        feedback(true, 'feedbackCorrect', 'feedbackTryAgain')
+        feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight', false)
       ], 
       conditional_function: () => {
         if (!trial) {
@@ -178,7 +178,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       if (index < sliderPractice.length - 1) {
         trials.push(
           {
-            ...feedback(true, 'feedbackCorrect', 'feedbackTryAgain'), 
+            ...feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight'), 
             conditional_function: () => {return true}, 
             post_trial_gap: 350
           } 

--- a/task-launcher/src/tasks/memory-game/timeline.ts
+++ b/task-launcher/src/tasks/memory-game/timeline.ts
@@ -12,7 +12,7 @@ const generatePracticeTrialTimeline = (reverse: boolean, tryAgainText: string, r
   const basicBlock = [
     getCorsiBlocks({ mode: 'display', isPractice: true, reverse }),
     getCorsiBlocks({ mode: 'input', isPractice: true, reverse }),
-    feedback(true, 'feedbackCorrect', tryAgainText),
+    feedback(true, 'feedbackCorrect', tryAgainText, true),
   ];
 
   const finalTimeline = [];
@@ -30,7 +30,7 @@ const getSecondRoundPracticeTrials = (reverse: boolean, tryAgainText: string) =>
       getCorsiBlocks({ mode: 'input', isPractice: true, reverse }),
       {
         timeline: [
-          feedback(true, 'feedbackCorrect', tryAgainText),
+          feedback(true, 'feedbackCorrect', tryAgainText, true),
         ],
         conditional_function: () => {
           return taskStore().isCorrect

--- a/task-launcher/src/tasks/shared/trials/feedback.ts
+++ b/task-launcher/src/tasks/shared/trials/feedback.ts
@@ -4,7 +4,7 @@ import { PageAudioHandler } from '../helpers';
 import { taskStore } from '../../../taskStore';
 
 // isPractice parameter is for tasks that don't have a corpus (e.g. memory game)
-export const feedback = (isPractice = false, correctFeedbackAudioKey: string, inCorrectFeedbackAudioKey: string) => {
+export const feedback = (isPractice = false, correctFeedbackAudioKey: string, inCorrectFeedbackAudioKey: string, showPrompt: boolean = false) => {
     return {
         timeline: [
             {
@@ -38,13 +38,13 @@ export const feedback = (isPractice = false, correctFeedbackAudioKey: string, in
                     return (
                         `<div class="lev-stimulus-container">
                             <div class="lev-row-container instruction">
-                                <p>${isCorrect ? t.feedbackCorrect : t.heartsAndFlowersTryAgain}</p>
+                                <p>${isCorrect ? t.feedbackCorrect : t.feedbackNotQuiteRight}</p>
                             </div>
                             <div class="lev-stim-content">
                                 <img src=${imageUrl} alt='Instruction graphic'/>
                             </div>
                     
-                            ${isCorrect ? '' :
+                            ${isCorrect || !showPrompt ? '' :
                              `<div class="lev-row-container instruction"'>
                                 <p>${promptOnIncorrect}</p>
                               </div>`


### PR DESCRIPTION
This PR allows instruction trials in the math corpus to include images, which is necessary for the slider block instruction trial. It also creates the option to not show the prompt at the bottom of the feedback screen.