### PR TITLE
Require button press or keydown on end screen to finish task

### DIFF
--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -9,6 +9,7 @@ import './styles/index.scss';
 import taskConfig from './tasks/taskConfig';
 import { RoarAppkit } from '@bdelab/roar-firekit';
 import { setTaskStore } from './taskStore';
+import { taskStore } from './taskStore';
 
 export let mediaAssets: MediaAssetsType;
 export class TaskLauncher {
@@ -69,6 +70,6 @@ export class TaskLauncher {
     const { jsPsych, timeline } = await this.init();
     hideLevanteLogoLoading();
     jsPsych.run(timeline);
-    await isTaskFinished(() => this.firekit?.run?.completed === true);
+    await isTaskFinished(() => this.firekit?.run?.completed === true && taskStore().taskComplete);
   }
 }

--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -20,6 +20,7 @@ import store from 'store2';
  * @property {boolean} storeItemId - Whether to store the item ID, default is false.
  * @property {boolean} isRoarApp - Whether the app is running in ROAR mode, default is false.
  * @property {boolean} maxTimeReached - Whether the max time has been reached, default is false.
+ * @property {boolean} taskComplete - Whether the task has ended - if true, the user should return to dashboard.
  * ------- Added after config is parsed -------
  * @property {number} totalTrials - Counter for total trials in the experiment, starting at 0.
  * @property {Object} corpora - Object containing the corpus data (stimulus).
@@ -107,6 +108,7 @@ export const setTaskStore = (config: TaskStoreDataType) => {
     stimulusBlocks: config.stimulusBlocks,
     gridSize: config.userMetadata.age > 4 ? 3 : 2,
     maxTimeReached: false,
+    taskComplete: false,
     stimulus: 'heart',
     stimulusSide: 'left',
     stimulusPosition: 0,

--- a/task-launcher/src/tasks/shared/trials/finishExperiment.ts
+++ b/task-launcher/src/tasks/shared/trials/finishExperiment.ts
@@ -11,11 +11,13 @@ export function finishExperiment() {
             const buttonId = (event.target as HTMLElement)?.id;
             if (buttonId === 'exit-button') {
                 document.body.innerHTML = '';
+                taskStore('taskComplete', true);
                 window.removeEventListener('click', removeDOMElements);
                 window.removeEventListener('keydown', removeDOMElements);
             }
         } else if (event.type === 'keydown'){
             document.body.innerHTML = '';
+            taskStore('taskComplete', true);
             window.removeEventListener('keydown', removeDOMElements);
             window.removeEventListener('click', removeDOMElements);
         }

--- a/task-launcher/src/tasks/shared/trials/taskFinished.ts
+++ b/task-launcher/src/tasks/shared/trials/taskFinished.ts
@@ -3,6 +3,12 @@ import { PageAudioHandler } from '../helpers';
 import { mediaAssets } from '../../..';
 import { taskStore } from '../../../taskStore';
 
+function endTask() {
+  taskStore('taskComplete', true);
+  window.removeEventListener('click', endTask);
+  window.removeEventListener('keydown', endTask);
+}
+
 export const taskFinished = (endMessage = 'taskFinished') => {
   return {
     type: jsPsychHTMLMultiResponse,
@@ -27,6 +33,9 @@ export const taskFinished = (endMessage = 'taskFinished') => {
     keyboard_choices: 'ALL_KEYS',
     button_html: '<button class="primary" style=margin-top:10%>Exit</button>',
     on_load: () => {
+      window.addEventListener('click', endTask);
+      window.addEventListener('keydown', endTask);
+
       if (mediaAssets.audio[endMessage]) {
         PageAudioHandler.playAudio(mediaAssets.audio[endMessage])
       }


### PR DESCRIPTION
The goal of this PR is to standardize the user's experience at the end of the task. Currently, the user is sometimes returned to the dashboard before they press the 'Exit' button on the end screen (particularly when they error/time out of a task), and sometimes only after they press it. This PR requires that the task does not end until the button is pressed, regardless of how the task is completed. 