### PR TITLE
Prevent SDS audio overlap between trials

### DIFF
--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -48,13 +48,10 @@ import store from 'store2';
  * @property {number} gridSize - Size of the grid in the memory game, default is 2x2.
  * ------- H&F & Memory Game only -------
  * @property {boolean} isCorrect - Whether the response to the previous trial was correct, default is false.
-<<<<<<< HEAD
  * --------- ToM only ---------
  * @property {Array} previousChoices - Array containing previously randomized order of choices for the current block.
-=======
  * ------- SDS only -------
  * @property {StimulusType[]} sequentialTrials - Should be run sequentially in blocks by trial number in an SDS CAT.
->>>>>>> main
  */
 
 export type TaskStoreDataType = {

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -44,17 +44,7 @@ export const afcMatch = {
     };
   },
   stimulus: () => {
-    const stim = taskStore().nextStimulus;
-    let audioFile = stim.audioFile;
-    if (
-      taskStore().heavyInstructions &&
-      stim.assessmentStage !== 'practice_response' &&
-      stim.trialType !== 'instructions'
-    ) {
-      audioFile += '-heavy';
-    }
-
-    return mediaAssets.audio[camelize(audioFile)];
+    return mediaAssets.audio.nullAudio;
   },
   prompt: () => {
     const stimulus = taskStore().nextStimulus;
@@ -112,6 +102,14 @@ export const afcMatch = {
       audioFile += '-heavy';
     }
 
+    const audioConfig: AudioConfigType = {
+      restrictRepetition: {
+        enabled: false, 
+        maxRepetitions: 2,
+      }
+    }
+    PageAudioHandler.playAudio(mediaAssets.audio[camelize(audioFile)], audioConfig); 
+
     const pageStateHandler = new PageStateHandler(audioFile, true);
     setupReplayAudio(pageStateHandler);
     const buttonContainer = document.getElementById('jspsych-audio-multi-response-btngroup') as HTMLDivElement;
@@ -156,6 +154,8 @@ export const afcMatch = {
 
     const endTime = performance.now();
     const calculatedRt = endTime - startTime;
+
+    PageAudioHandler.stopAndDisconnectNode();
 
     // save data
     jsPsych.data.addDataToLastTrial({

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -143,7 +143,7 @@ export const afcMatch = {
           const requiredSelections = stim.requiredSelections;
 
           if (selectedCards.length === requiredSelections) {
-            jsPsych.finishTrial();
+            setTimeout(() => jsPsych.finishTrial(), 500);
           }
         }
         setTimeout(() => enableBtns(responseBtns), 500);


### PR DESCRIPTION
The audio overlap between trials issue has been fixed for all other tasks by switching to `html-multi-response` and using the `PageAudioHandler` class to play audio, but for some reason using `html-multi-response` here was causing an error in the plugin code. To fix this, I left it as an `audio-multi-response` trial but with `nullAudio` as the stimulus. 