### PR TITLE
fix(): Making the overlay warnings language sensitive

### DIFF
--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -66,11 +66,12 @@ export class TaskLauncher {
   }
 
   async run() {
-    const pageSetup = new InitPageSetup(4000);
     showLevanteLogoLoading();
     const { jsPsych, timeline } = await this.init();
     hideLevanteLogoLoading();
     jsPsych.run(timeline);
+    const translations = taskStore().translations;
+    const pageSetup = new InitPageSetup(4000, translations);
     pageSetup.init();
     await isTaskFinished(() => this.firekit?.run?.completed === true && taskStore().taskComplete);
   }

--- a/task-launcher/src/utils/initPageSetup.ts
+++ b/task-launcher/src/utils/initPageSetup.ts
@@ -53,7 +53,7 @@ export class InitPageSetup {
   createSmallDeviceOverlayDiv() {
     const smallDeviceOverlayDiv = document.createElement('div');
     smallDeviceOverlayDiv.classList.add('lev-overlay-default');
-    const text = this.#translations.generalDeviceType ||
+    const text = this.#translations.generalDevice ||
       'Please use a tablet or a desktop in landscape mode for optimal experience';
     const textHolder = document.createElement('div');
     textHolder.classList.add(...['lev-row-container', 'header']);

--- a/task-launcher/src/utils/initPageSetup.ts
+++ b/task-launcher/src/utils/initPageSetup.ts
@@ -53,7 +53,7 @@ export class InitPageSetup {
   createSmallDeviceOverlayDiv() {
     const smallDeviceOverlayDiv = document.createElement('div');
     smallDeviceOverlayDiv.classList.add('lev-overlay-default');
-    const text = this.#translations.generalDevice ||
+    const text = this.#translations.generalDeviceType ||
       'Please use a tablet or a desktop in landscape mode for optimal experience';
     const textHolder = document.createElement('div');
     textHolder.classList.add(...['lev-row-container', 'header']);

--- a/task-launcher/src/utils/initPageSetup.ts
+++ b/task-launcher/src/utils/initPageSetup.ts
@@ -11,10 +11,12 @@ export class InitPageSetup {
   warningDuration: number;
   rotateOverlayDiv: HTMLDivElement;
   smallDeviceOverlayDiv: HTMLDivElement;
+  #translations: Record<string, string>;
   #overlayShown: boolean;
   #timeout?: number;
 
-  constructor(warningDuration: number) {
+  constructor(warningDuration: number, translations: Record<string, string>) {
+    this.#translations = translations;
     this.warningDuration = warningDuration;
     this.rotateOverlayDiv = this.createRotateOverlayDiv();
     this.smallDeviceOverlayDiv = this.createSmallDeviceOverlayDiv();
@@ -33,7 +35,8 @@ export class InitPageSetup {
   createRotateOverlayDiv() {
     const rotateOverlayDiv = document.createElement('div');
     rotateOverlayDiv.classList.add('lev-overlay-default');
-    const text = 'Please rotate your device for optimal experience';
+    const text = this.#translations.generalRotateDevice ||
+      'Please rotate your device for optimal experience';
     const textHolder = document.createElement('div');
     textHolder.classList.add(...['lev-row-container', 'header']);
     const textElement = document.createElement('p');
@@ -50,7 +53,8 @@ export class InitPageSetup {
   createSmallDeviceOverlayDiv() {
     const smallDeviceOverlayDiv = document.createElement('div');
     smallDeviceOverlayDiv.classList.add('lev-overlay-default');
-    const text = 'Please use a tablet or a desktop in landscape mode for optimal experience';
+    const text = this.#translations.generalDeviceType ||
+      'Please use a tablet or a desktop in landscape mode for optimal experience';
     const textHolder = document.createElement('div');
     textHolder.classList.add(...['lev-row-container', 'header']);
     const textElement = document.createElement('p');


### PR DESCRIPTION
This should make the overlay warnings for device type, language sensitive with some default texts. The keys of the texts would be:
general-rotate-device: For device rotation
general-device-type: For small device

We need to add them to the translations file.