### PR TITLE
Allow scrolling for Roar-Inference

### DIFF
--- a/task-launcher/src/styles/pages/_roar-inference.scss
+++ b/task-launcher/src/styles/pages/_roar-inference.scss
@@ -74,6 +74,6 @@
 }
 
 .jspsych-display-element .jspsych-content-wrapper .jspsych-content {
-  overflow-x: scroll;
-  overflow-y: scroll;
+  overflow-x: auto;
+  overflow-y: auto;
 }

--- a/task-launcher/src/styles/pages/_roar-inference.scss
+++ b/task-launcher/src/styles/pages/_roar-inference.scss
@@ -2,9 +2,9 @@
 
 .roar-inference-btn {
   display: flex;
-  width: 40vh;
-  height: 9vh;
   padding: 8px;
+  width: 50vh;
+  height: 15vh;
   justify-content: center;
   align-items: center;
   gap: 8px;
@@ -24,8 +24,10 @@
     background-color: gainsboro;
   }
 
-  @include respond-to('huge') {
-    font-size: 1.5rem;
+  @include respond-to('very-large') {
+    width: 40vh;
+    height: 10vh;
+    font-size: 1.2rem;
   }
 }
 
@@ -35,28 +37,20 @@
   border-radius: 0;
   background-color: transparent;
   color: black;
-  font-size: x-large;
   padding-bottom: 0;
-  margin-right: 25%;
-  margin-left: 25%;
+  margin-left: 10%;
+  margin-right: 10%;
+  font-size: large;
+  margin-top: 10%;
 
   p {
     margin-bottom: 0;
   }
 
-  @include respond-to('small-medium') {
-    margin-left: 15%;
-    margin-right: 15%;
-    font-size: x-large;
-  }
-
-  @include respond-to('small') {
-    margin-left: 5%;
-    margin-right: 5%;
-  }
-
   @include respond-to('huge') {
     font-size: xx-large;
+    margin-left: 15%;
+    margin-right: 15%;
   }
 }
 
@@ -66,11 +60,20 @@
   border-radius: 0;
   background-color: transparent;
   color: black;
-  font-size: x-large;
+  font-size: large;
   padding: 12px;
   font-weight: bold;
 
   @include respond-to('huge') {
     font-size: xx-large;
   }
+}
+
+.lev-response-row.multi-stack {
+  margin-bottom: 1rem;
+}
+
+.jspsych-display-element .jspsych-content-wrapper .jspsych-content {
+  overflow-x: scroll;
+  overflow-y: scroll;
 }

--- a/task-launcher/src/styles/pages/_roar-inference.scss
+++ b/task-launcher/src/styles/pages/_roar-inference.scss
@@ -41,7 +41,6 @@
   margin-left: 10%;
   margin-right: 10%;
   font-size: large;
-  margin-top: 10%;
 
   p {
     margin-bottom: 0;
@@ -69,11 +68,7 @@
   }
 }
 
-.lev-response-row.multi-stack {
-  margin-bottom: 1rem;
-}
-
-.jspsych-display-element .jspsych-content-wrapper .jspsych-content {
+.inference-scroll {
   overflow-x: auto;
   overflow-y: auto;
 }

--- a/task-launcher/src/tasks/roar-inference/helpers/config.ts
+++ b/task-launcher/src/tasks/roar-inference/helpers/config.ts
@@ -30,6 +30,7 @@ export const getLayoutConfig = (
     value: stimulus.prompt,
     displayValue: undefined,
   };
+  defaultConfig.classOverrides.stimulusContainerClassList = ['inference-scroll'];
   defaultConfig.disableButtonsWhenAudioPlaying = true;
   if (!defaultConfig.isInstructionTrial) {
     const mappedDistractors = mapDistractorsToString(distractors);

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -196,11 +196,12 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   if (!isPracticeTrial && !isInstructionTrial) {
     trialsOfCurrentType += 1;
   }
-  const jsPsychContent = document.querySelector('.jspsych-content') as HTMLElement;
 
-if (itemLayoutConfig?.classOverrides.stimulusContainerClassList.includes('inference-scroll')) {
-  jsPsychContent?.classList.add('inference-scroll');
-}
+  if (itemLayoutConfig?.classOverrides.stimulusContainerClassList.includes('inference-scroll')) {
+    const jsPsychContent = document.querySelector('.jspsych-content') as HTMLElement;
+
+    jsPsychContent?.classList.add('inference-scroll');
+  }
 
   if (stim.trialType !== 'instructions') {
     const buttonContainer = document.getElementById('jspsych-html-multi-response-btngroup') as HTMLDivElement;

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -196,6 +196,11 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   if (!isPracticeTrial && !isInstructionTrial) {
     trialsOfCurrentType += 1;
   }
+  const jsPsychContent = document.querySelector('.jspsych-content') as HTMLElement;
+
+if (itemLayoutConfig?.classOverrides.stimulusContainerClassList.includes('inference-scroll')) {
+  jsPsychContent?.classList.add('inference-scroll');
+}
 
   if (stim.trialType !== 'instructions') {
     const buttonContainer = document.getElementById('jspsych-html-multi-response-btngroup') as HTMLDivElement;
@@ -311,6 +316,8 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
   } else if (taskStore().numIncorrect >= taskStore().maxIncorrect) {
     finishExperiment();
   }
+  document.querySelector('.jspsych-content')?.classList.remove('inference-scroll');
+
 }
 
 export interface AfcStimulusInput {


### PR DESCRIPTION
When the story is very very big, on very small devices they can't see the whole stimuli.
Example: 
![image](https://github.com/user-attachments/assets/6b5677fd-0df5-4777-8869-7405ca6db4f4)

After (I had to take it with my phone to show the scrolling bar):
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/abf31c44-c75e-4d15-a2f3-436bfd82cefb" />