### PR TITLE
fix(): Orientation Type bug

### DIFF
--- a/task-launcher/src/utils/initPageSetup.ts
+++ b/task-launcher/src/utils/initPageSetup.ts
@@ -81,7 +81,9 @@ export class InitPageSetup {
 
   onOrientationChange() {
     const { screen } = window;
-    const isPortrait = screen.orientation.type.includes('portrait');
+    const isPortrait = screen.orientation?.type 
+      ? screen.orientation.type.includes('portrait')
+      : screen.availHeight > screen.availWidth; // To support old browsers
     const primaryDimension = isPortrait ? screen.availWidth : screen.availHeight;
     if (primaryDimension < 500) {
       this.showOverlay(this.smallDeviceOverlayDiv);

--- a/task-launcher/src/utils/initPageSetup.ts
+++ b/task-launcher/src/utils/initPageSetup.ts
@@ -81,7 +81,7 @@ export class InitPageSetup {
 
   onOrientationChange() {
     const { screen } = window;
-    const isPortrait = screen.orientation?.type 
+    const isPortrait = screen?.orientation?.type
       ? screen.orientation.type.includes('portrait')
       : screen.availHeight > screen.availWidth; // To support old browsers
     const primaryDimension = isPortrait ? screen.availWidth : screen.availHeight;


### PR DESCRIPTION
Adding a default way to calculate the orientation. This should fix the bug here:
https://levante-framework.sentry.io/issues/6599022203/?alert_rule_id=15684260&alert_timestamp=1746973666780&alert_type=email&environment=production&notification_uuid=0e75f140-eaf4-4202-b3cf-5f80a5ca31e1&project=4508480347832320&referrer=alert_email