### PR TITLE
Math downward extension

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -173,6 +173,18 @@ button {
     }
   }
 
+  &.slider {
+    @extend .button-base;
+    background: $border-accent;
+    border-color: $bg-accent_secondary;
+    box-shadow:
+      $button-secondary-box-shadow $bg-accent_secondary inset,
+      $button-secondary-inner-shadow $bg-button-secondary inset;
+    font-size: $font-size-lm;
+    width: 16px;
+    height: 16x;
+  }
+
   &.replay {
     // This is also used by the Hearts and Flowers task
     position: absolute;

--- a/task-launcher/src/styles/pages/_egma-math.scss
+++ b/task-launcher/src/styles/pages/_egma-math.scss
@@ -66,3 +66,48 @@
   background-color: #275bdd;
   border-radius: 50%;
 }
+
+// create separate class for number line with buttons that hides thumb
+.number-line-buttons {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 8px;
+  border-radius: 16px;
+  border: 1px solid #bdc1c3;
+}
+
+/* Track: webkit browsers */
+.number-line-buttons::-webkit-slider-runnable-track {
+  height: 8px;
+  border-radius: 2px;
+}
+
+/* Track: Mozilla Firefox */
+.number-line-buttons::-moz-range-track {
+  height: 8px;
+  border-radius: 2px;
+}
+
+/* Thumb: webkit */
+.number-line-buttons::-webkit-slider-thumb {
+  /* removing default appearance */
+  -webkit-appearance: none;
+  appearance: none;
+  /* creating a custom design */
+  margin-top: -3px;
+  height: 0px; // thumb should not be visible
+  width: 15px;
+  background-color: #275bdd;
+  border-radius: 50%;
+}
+
+/* Thumb: Firefox */
+.number-line-buttons::-moz-range-thumb {
+  /* removing default appearance */
+  -webkit-appearance: none;
+  appearance: none;
+  height: 0px;
+  width: 15px;
+  background-color: #275bdd;
+  border-radius: 50%;
+}

--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -48,13 +48,10 @@ import store from 'store2';
  * @property {number} gridSize - Size of the grid in the memory game, default is 2x2.
  * ------- H&F & Memory Game only -------
  * @property {boolean} isCorrect - Whether the response to the previous trial was correct, default is false.
-<<<<<<< HEAD
  * --------- ToM only ---------
  * @property {Array} previousChoices - Array containing previously randomized order of choices for the current block.
-=======
  * ------- SDS only -------
  * @property {StimulusType[]} sequentialTrials - Should be run sequentially in blocks by trial number in an SDS CAT.
->>>>>>> main
  */
 
 export type TaskStoreDataType = {

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -33,8 +33,9 @@ export const getLayoutConfig = (
     const mappedDistractors = mapDistractorsToString(distractors);
     const prepChoices = prepareChoices(answer.toString(), mappedDistractors, 'yes', trialType); 
     defaultConfig.prompt.enabled = false;
-    defaultConfig.isImageButtonResponse = false;
-    defaultConfig.classOverrides.buttonClassList = ['secondary'];
+    defaultConfig.isImageButtonResponse = (trialType === "Non-symbolic Number Identification");
+    defaultConfig.classOverrides.buttonClassList = 
+      trialType === "Non-symbolic Number Identification" ? ['image-medium'] : ['secondary'];
     defaultConfig.response = {
       target: prepChoices.target,
       displayValues: prepChoices.choices,

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -23,7 +23,7 @@ export const getLayoutConfig = (
   const stimItem = convertItemToString(stimulus.item);
   defaultConfig.isPracticeTrial = stimulus.assessmentStage === 'practice_response';
   defaultConfig.isInstructionTrial = stimulus.trialType === 'instructions';
-  defaultConfig.showStimImage = stimulus.trialType === 'instructions' || stimulus.trialType === 'Counting';
+  defaultConfig.showStimImage = stimulus.trialType === 'instructions' || stimulus.trialType.includes('Counting');
   defaultConfig.stimText = {
     value: stimItem,
     displayValue: undefined,
@@ -45,7 +45,7 @@ export const getLayoutConfig = (
       values: prepChoices.originalChoices,
       targetIndex: prepChoices.correctResponseIdx,
     };
-    if (!['Number Identification', 'Number Comparison', 'Counting'].includes(stimulus.trialType)) {
+    if (!['Number Identification', 'Number Comparison', 'Counting', 'Counting AFC'].includes(stimulus.trialType)) {
       defaultConfig.stimText = {
         value: stimItem,
         displayValue: stimulus.trialType === 'Fraction' ? fractionToMathML(stimItem) : stimItem,

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -23,7 +23,7 @@ export const getLayoutConfig = (
   const stimItem = convertItemToString(stimulus.item);
   defaultConfig.isPracticeTrial = stimulus.assessmentStage === 'practice_response';
   defaultConfig.isInstructionTrial = stimulus.trialType === 'instructions';
-  defaultConfig.showStimImage = stimulus.trialType === 'instructions';
+  defaultConfig.showStimImage = stimulus.trialType === 'instructions' || stimulus.trialType === 'Counting';
   defaultConfig.stimText = {
     value: stimItem,
     displayValue: undefined,
@@ -31,18 +31,21 @@ export const getLayoutConfig = (
   defaultConfig.inCorrectTrialConfig.onIncorrectTrial = 'skip';
   if (!defaultConfig.isInstructionTrial) {
     const mappedDistractors = mapDistractorsToString(distractors);
-    const prepChoices = prepareChoices(answer.toString(), mappedDistractors, 'yes', trialType); 
+    const prepChoices = trialType === "Counting" ? 
+      prepareChoices(answer.toString(), mappedDistractors, 'no', trialType) :
+      prepareChoices(answer.toString(), mappedDistractors, 'yes', trialType); 
     defaultConfig.prompt.enabled = false;
     defaultConfig.isImageButtonResponse = (trialType === "Non-symbolic Number Identification");
     defaultConfig.classOverrides.buttonClassList = 
-      trialType === "Non-symbolic Number Identification" ? ['image-medium'] : ['secondary'];
+      trialType === "Non-symbolic Number Identification" ? ['image-medium'] : 
+      (trialType === "Counting" ? ['primary'] : ['secondary']); 
     defaultConfig.response = {
       target: prepChoices.target,
       displayValues: prepChoices.choices,
       values: prepChoices.originalChoices,
       targetIndex: prepChoices.correctResponseIdx,
     };
-    if (!['Number Identification', 'Number Comparison'].includes(stimulus.trialType)) {
+    if (!['Number Identification', 'Number Comparison', 'Counting'].includes(stimulus.trialType)) {
       defaultConfig.stimText = {
         value: stimItem,
         displayValue: stimulus.trialType === 'Fraction' ? fractionToMathML(stimItem) : stimItem,

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -38,7 +38,7 @@ export const getLayoutConfig = (
     defaultConfig.isImageButtonResponse = (trialType === "Non-symbolic Number Identification");
     defaultConfig.classOverrides.buttonClassList = 
       trialType === "Non-symbolic Number Identification" ? ['image-medium'] : 
-      (trialType === "Counting" ? ['primary'] : ['secondary']); 
+      (trialType === "Counting" ? [] : ['secondary']); 
     defaultConfig.response = {
       target: prepChoices.target,
       displayValues: prepChoices.choices,

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -61,13 +61,12 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
 
   const { runCat, heavyInstructions } = taskStore();
 
-  if (heavyInstructions) {
-    corpus = corpus.filter(trial => {
-      return trial.block_index === "0";
-    })
+  // block 4 is only for younger kids
+  corpus = corpus.filter(trial => {
+    return heavyInstructions ? trial.block_index === "3" : trial.block_index !== "3";
+  });
 
-    taskStore('totalTrials', corpus.length);
-  }
+  taskStore('totalTrials', corpus.length);
 
   const layoutConfigMap: Record<string, LayoutConfigType> = {};
   let i = 0;

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -55,11 +55,19 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
 
   const timeline = [preloadTrials, initialTimeline];
 
-  const corpus: StimulusType[] = taskStore().corpora.stimulus;
+  let corpus: StimulusType[] = taskStore().corpora.stimulus;
   const translations: Record<string, string> = taskStore().translations;
   const validationErrorMap: Record<string, string> = {};
 
-  const { runCat } = taskStore();
+  const { runCat, heavyInstructions } = taskStore();
+
+  if (heavyInstructions) {
+    corpus = corpus.filter(trial => {
+      return trial.block_index === "0";
+    })
+
+    taskStore('totalTrials', corpus.length);
+  }
 
   const layoutConfigMap: Record<string, LayoutConfigType> = {};
   let i = 0;
@@ -178,7 +186,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       conditional_function: () => {
         return (
           !taskStore().isCorrect &&
-          taskStore().testPhase === false &&
+          !taskStore().testPhase &&
           (taskStore().nextStimulus.trialType === 'Number Line Slider' || runCat) &&
           taskStore().nextStimulus.assessmentStage === 'test_response'
         );

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -282,6 +282,11 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
         // overlay response buttons on top of slider
         responseChoices.forEach((choice: any, i: number) => {
           const sliderButton = document.createElement('button');
+
+          if (stim.assessmentStage === 'practice_response') {
+            sliderButton.classList.add('practice-btn');
+          }
+
           sliderButton.classList.add('slider'); 
           sliderButton.style.position = 'absolute'; 
           sliderButton.style.top = '-12px';

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -1,6 +1,7 @@
 import HTMLSliderResponse from '@jspsych/plugin-html-slider-response';
 import _shuffle from 'lodash/shuffle';
 import _toNumber from 'lodash/toNumber';
+import _range from 'lodash/range';
 import { jsPsych, isTouchScreen, cat } from '../../taskSetup';
 //@ts-ignore
 import { camelize } from '@bdelab/roar-utils';
@@ -41,9 +42,8 @@ function addKeyHelpers(el: HTMLElement, keyIndex: number) {
   }
 }
 
-function setUpAudio(responseType: string) {
-  const cue = responseType === 'button' ? 'numberLinePrompt1' : 'numberLineSliderPrompt1';
-  const audioFile = mediaAssets.audio[cue] || '';
+function setUpAudio(cue: string) {
+  const audioFile = mediaAssets.audio[camelize(cue)] || '';
 
   const audioConfig: AudioConfigType = {
     restrictRepetition: {
@@ -67,11 +67,12 @@ function captureValue(
   event: Event & { key?: string },
   i: number,
   isPractice: boolean,
+  choice?: string
 ) {
   if (event?.key) {
     chosenAnswer = _toNumber(keyboardResponseMap[event.key.toLowerCase()]);
   } else {
-    chosenAnswer = _toNumber(btnElement?.textContent);
+    chosenAnswer = choice ? _toNumber(choice) : _toNumber(btnElement?.textContent);
   }
 
   responseIdx = i;
@@ -119,12 +120,16 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
         <button id="replay-btn-revisited" class="replay">
           ${replayButtonSvg}
         </button>
-        <div class="lev-row-container instruction">
-          <p>
-            ${t[camelize(stim.audioFile)]}
-            ${isSlider ? '<br /> ' + stim.answer : ''}
-          </p>
-        </div>
+          ${
+            stim.trialType !== 'Number Line Buttons' ? 
+              `<div class="lev-row-container instruction">
+                <p>
+                  ${t[camelize(stim.audioFile)]}
+                  ${isSlider ? '<br /> ' + stim.answer : ''}
+                </p> 
+              </div>`
+            : ''
+          }
       </div>
     `;
     },
@@ -142,9 +147,10 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
         // const max = stim.item[1] === 1 ? 100 : stim.item[1];
         const max = stim.item[1];
         sliderStart = getRandomValue(max, stim.answer);
-      } else {
-        // sliderStart = stim.answer < 1 ? stim.answer * 100 : stim.answer;
+      } else if (stim.trialType === 'Number Line 4afc') {
         sliderStart = stim.answer;
+      } else {
+        sliderStart = stim.item[1];
       }
 
       return sliderStart;
@@ -192,6 +198,7 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
       responseRow.style.justifyContent = 'center';
       responseRow.style.alignItems = 'center';
       const buttonContainer = document.createElement('div');
+      const sliderContainer = document.getElementsByClassName('jspsych-html-slider-response-container')[0] as HTMLDivElement; 
 
       if (buttonLayout === 'diamond' && response.values.length === 4) {
         // have to do it in the runtime
@@ -245,7 +252,7 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
 
           buttonContainer.appendChild(btnWrapper);
         }
-      } else {
+      } else if (stim.trialType === "Number Line Slider") {
         const continueBtn = document.getElementById('jspsych-html-slider-response-next');
         if (continueBtn) {
           continueBtn.classList.add('primary');
@@ -254,15 +261,44 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
         const slider = document.getElementById('jspsych-html-slider-response-response') as HTMLButtonElement;
 
         slider.addEventListener('input', () => (chosenAnswer = Number(slider.value)));
+      } else {
+        // disable continue button and make invisible
+        const continueBtn = document.getElementById('jspsych-html-slider-response-next') as HTMLButtonElement;
+        continueBtn.disabled = true;
+        continueBtn.style.visibility = 'hidden';
+
+        // lower labels to give room for slider buttons
+        const labels = sliderContainer.children[1].children as any as HTMLDivElement[]; 
+        for (let i = 0; i < labels.length; i++) {
+          labels[i].style.top = '50px';
+        }
+
+        // add slider styling
+        const progress = (Number(slider.value) * 100) / (Number(slider.max) - Number(slider.min));
+        slider.disabled = true;
+        slider.style.background = `linear-gradient(to right, #275BDD ${progress}%, #edf0ed ${progress}%)`;
+        slider.classList.add('number-line-buttons');
+
+        // overlay response buttons on top of slider
+        responseChoices.forEach((choice: any, i: number) => {
+          const sliderButton = document.createElement('button');
+          sliderButton.classList.add('slider'); 
+          sliderButton.style.position = 'absolute'; 
+          sliderButton.style.top = '-12px';
+
+          const stepPercent = 100 / Number(slider.max);
+          sliderButton.style.left = `calc(${stepPercent * Number(choice)}% - ${stepPercent / 2}%)`;
+
+          sliderButton.addEventListener('click', (e) => captureValue(sliderButton, e, i, isPractice, choice));
+
+          sliderContainer.appendChild(sliderButton);
+        });
       }
 
       responseRow.appendChild(buttonContainer);
       wrapper.appendChild(responseRow);
 
-      const stimulus = trial || taskStore().nextStimulus;
-      const responseType = stimulus.trialType.includes('4afc') ? 'button' : 'slider';
-
-      setUpAudio(responseType);
+      setUpAudio(stim.audioFile);
 
       if (isPractice) {
         let feedbackHandler;
@@ -289,7 +325,7 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
       const runCat = taskStore().runCat;
 
       const sliderScoringThreshold = 0.05; // proportion of maximum slider value that response must fall within to be scored correct
-      if (stimulus.trialType === 'Number Line 4afc') {
+      if (stimulus.trialType === 'Number Line 4afc' || stimulus.trialType === 'Number Line Buttons') {
         if (isPractice) {
           data.correct = taskStore().incorrectPracticeResponses.length === 0;
         } else {
@@ -316,7 +352,9 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
       }
 
       const response = chosenAnswer;
-      const responseType = stimulus.trialType.includes('4afc') ? 'button' : 'slider';
+      const responseType = 
+        stimulus.trialType.includes('Slider') ? 
+        'slider' : (stimulus.trialType.includes('4afc') ? 'button' : 'slider-button');
       const answer = stimulus.answer;
 
       jsPsych.data.addDataToLastTrial({
@@ -342,7 +380,7 @@ export const slider = (layoutConfigMap: Record<string, LayoutConfigType>, trial?
         taskStore.transact('testTrialCount', (oldVal: number) => oldVal + 1);
       }
 
-      if (responseType === 'button') {
+      if (responseType === 'button' || responseType === 'slider-button') {
         const calculatedRt = Math.round(endTime - startTime);
 
         jsPsych.data.addDataToLastTrial({

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -30,8 +30,7 @@ export const getStimulus = (corpusType: string, blockNumber?: number) => {
   taskStore('nextStimulus', itemSuggestion.nextStimulus);
 
   if (
-    itemSuggestion.nextStimulus.assessmentStage === 'practice_response' ||
-    itemSuggestion.nextStimulus.trialType === 'instructions'
+    itemSuggestion.nextStimulus.assessmentStage === 'practice_response'
   ) {
     taskStore('testPhase', false);
   }

--- a/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
+++ b/task-launcher/src/tasks/shared/helpers/setSkipCurrentBlock.ts
@@ -19,7 +19,11 @@ function skipBlock() {
 }
 
 export const setSkipCurrentBlock = (skipTrialType: string) => {
-  if (!!store.page.get('failedPrimaryTrials') && taskStore().numIncorrect >= 1) {
+  if (
+    !!store.page.get('failedPrimaryTrials') && 
+    taskStore().numIncorrect >= 1 &&
+    !taskStore().heavyInstructions
+  ) {
     taskStore('numIncorrect', 0);
     store.page.set('skipCurrentBlock', skipTrialType);
     skipBlock();


### PR DESCRIPTION
This PR adds a few new math trial types for younger kids and runs only block 3 of the corpus (which will contain the downward extension version of math) if `heavyInstructions` is turned on.