### PR TITLE
Look for touch rather than click events if touch screen is detected

### DIFF
--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -9,7 +9,7 @@ import {
   camelize,
 } from '../../shared/helpers';
 import { finishExperiment } from '../../shared/trials';
-import { jsPsych } from '../../taskSetup';
+import { isTouchScreen, jsPsych } from '../../taskSetup';
 import Cypress from 'cypress';
 import { taskStore } from '../../../taskStore';
 import { handleStaggeredButtons } from '../../shared/helpers/staggerButtons';
@@ -241,11 +241,15 @@ export const stimulus = (trial?: StimulusType) => {
           .map((btnDiv) => btnDiv.firstChild)
           .filter((btn) => !!btn) as HTMLButtonElement[];
 
-        practiceBtns.forEach((card, i) =>
-          card.addEventListener('click', async (e) => {
-            handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob');
-          }),
-        );
+        practiceBtns.forEach((card, i) => {
+          isTouchScreen ?
+            card.addEventListener('touchend', async (e) => {
+              handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob');
+            }) :
+            card.addEventListener('click', async (e) => {
+              handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob'); 
+            }); 
+        });
       }
     },
     on_finish: (data: any) => {

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -242,13 +242,11 @@ export const stimulus = (trial?: StimulusType) => {
           .filter((btn) => !!btn) as HTMLButtonElement[];
 
         practiceBtns.forEach((card, i) => {
-          isTouchScreen ?
-            card.addEventListener('touchend', async (e) => {
+          const eventType = isTouchScreen ? 'touchend' : 'click';
+         
+          card.addEventListener(eventType, (e) => {
               handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob');
-            }) :
-            card.addEventListener('click', async (e) => {
-              handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob'); 
-            }); 
+          }); 
         });
       }
     },

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -11,11 +11,15 @@ export function addPracticeButtonListeners(stim: StimulusType, isTouchScreen: bo
   const practiceBtns: NodeListOf<HTMLButtonElement> = document.querySelectorAll('.practice-btn');
   let keyboardFeedbackHandler: (ev: KeyboardEvent) => void;
 
-  practiceBtns.forEach((btn, i) =>
-    btn.addEventListener('click', async (e) => {
-      handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
-    }),
-  );
+  practiceBtns.forEach((btn, i) => {
+    isTouchScreen ? 
+      btn.addEventListener('touchend', async (e) => {
+        handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
+      }) :
+      btn.addEventListener('click', async (e) => {
+        handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
+      })
+  });
 
   if (!isTouchScreen) {
     keyboardFeedbackHandler = (e: KeyboardEvent) => keyboardBtnFeedback(e, practiceBtns, stim, itemConfig);

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -12,13 +12,11 @@ export function addPracticeButtonListeners(stim: StimulusType, isTouchScreen: bo
   let keyboardFeedbackHandler: (ev: KeyboardEvent) => void;
 
   practiceBtns.forEach((btn, i) => {
-    isTouchScreen ? 
-      btn.addEventListener('touchend', async (e) => {
+    const eventType = isTouchScreen ? 'touchend' : 'click';
+      
+    btn.addEventListener(eventType, (e) => {
         handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
-      }) :
-      btn.addEventListener('click', async (e) => {
-        handlePracticeButtonPress(btn, stim, practiceBtns, false, i, itemConfig);
-      })
+    }); 
   });
 
   if (!isTouchScreen) {


### PR DESCRIPTION
Replaces `click` event listeners with `touchend` listeners for practice buttons, which have sometimes been unresponsive on tablets. 