### PR TITLE
Adding a few more events to see task related status

### DIFF
--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -71,6 +71,13 @@ export class TaskLauncher {
     showLevanteLogoLoading();
     const { jsPsych, timeline } = await this.init();
     hideLevanteLogoLoading();
+    const logger = Logger.getInstance();
+    logger.capture('Task Launched', {
+      taskName: this.gameParams.taskName,
+      language: this.gameParams.language,
+      gameParams: this.gameParams,
+      userParams: this.userParams,
+    });
     jsPsych.run(timeline);
     const translations = taskStore().translations;
     const pageSetup = new InitPageSetup(4000, translations);

--- a/task-launcher/src/tasks/shared/trials/finishExperiment.ts
+++ b/task-launcher/src/tasks/shared/trials/finishExperiment.ts
@@ -2,6 +2,7 @@ import { jsPsych } from '../../taskSetup';
 import { PageAudioHandler } from '../helpers';
 import { mediaAssets } from '../../..';
 import { taskStore } from '../../../taskStore';
+import { Logger } from '../../../utils';
 
 export function finishExperiment() {
   const t = taskStore().translations;
@@ -23,6 +24,11 @@ export function finishExperiment() {
   };
   window.addEventListener('click', removeDOMElements);
   window.addEventListener('keydown', removeDOMElements);
+  const logger = Logger.getInstance();
+  logger.capture('Task Aborted', {
+    taskName: taskStore().task,
+    taskFinished: taskStore().taskComplete,
+  });
 
   jsPsych.endExperiment(
     `<div class='lev-stimulus-container'>

--- a/task-launcher/src/tasks/shared/trials/taskFinished.ts
+++ b/task-launcher/src/tasks/shared/trials/taskFinished.ts
@@ -2,6 +2,7 @@ import jsPsychHTMLMultiResponse from '@jspsych-contrib/plugin-html-multi-respons
 import { PageAudioHandler } from '../helpers';
 import { mediaAssets } from '../../..';
 import { taskStore } from '../../../taskStore';
+import { Logger } from '../../../utils';
 
 function endTask() {
   taskStore('taskComplete', true);
@@ -39,6 +40,11 @@ export const taskFinished = (endMessage = 'taskFinished') => {
       if (mediaAssets.audio[endMessage]) {
         PageAudioHandler.playAudio(mediaAssets.audio[endMessage]);
       }
+      const logger = Logger.getInstance();
+      logger.capture('Task Finished', {
+        taskName: taskStore().task,
+        taskFinished: taskStore().taskComplete,
+      });
     },
     // trial_duration: 1000,
   };


### PR DESCRIPTION
This ticket adds the following events:
1. Task Launch (after loading screen is over)
2. Task Finished (task is fully completed)
3. Task Aborted (task is stopped due to user errors)

