### PR TITLE
Prevent timeout interrupting the stimulus

### DIFF
--- a/task-launcher/src/taskStore/index.ts
+++ b/task-launcher/src/taskStore/index.ts
@@ -20,6 +20,8 @@ import store from 'store2';
  * @property {boolean} storeItemId - Whether to store the item ID, default is false.
  * @property {boolean} isRoarApp - Whether the app is running in ROAR mode, default is false.
  * @property {boolean} maxTimeReached - Whether the max time has been reached, default is false.
+ * @property {number} maxTime - Time limit set for the task.
+ * @property {number} startTime - Time at which the task started. 
  * @property {boolean} taskComplete - Whether the task has ended - if true, the user should return to dashboard.
  * ------- Added after config is parsed -------
  * @property {number} totalTrials - Total number trials, including practice and instructions.
@@ -75,6 +77,7 @@ export type TaskStoreDataType = {
   semThreshold: number;
   startingTheta: number;
   language?: string;
+  maxTime?: number
 };
 
 /**
@@ -120,6 +123,7 @@ export const setTaskStore = (config: TaskStoreDataType) => {
     isCorrect: false,
     inferenceNumStories: config.inferenceNumStories,
     testPhase: false,
+    maxTime: config.maxTime,
   });
 };
 

--- a/task-launcher/src/tasks/shared/helpers/appTimer.ts
+++ b/task-launcher/src/tasks/shared/helpers/appTimer.ts
@@ -8,6 +8,8 @@ import { PageStateHandler} from './PageStateHandler';
 
 // define timerId here so that it can be cleared if task ends early
 let timerId: any;
+// buffer in milliseconds after presentation of stimulus to allow some time to answer
+const RESPONSE_BUFFER = 2000;  
 
 export const startAppTimer = (maxTimeInMinutes: number, finishExperiment: () => void) => {
   // Minimum time is 1 minute
@@ -25,7 +27,7 @@ export const startAppTimer = (maxTimeInMinutes: number, finishExperiment: () => 
 // function for ending the task if the next trial
 export async function checkEndTaskEarly(timeRemaining: number, stimAudio: string) {
     const pageStateHandler = new PageStateHandler(stimAudio, false); 
-    const minTrialDuration = await pageStateHandler.getStimulusDurationMs() + 2000; 
+    const minTrialDuration = await pageStateHandler.getStimulusDurationMs() + RESPONSE_BUFFER; 
 
     if (timeRemaining < minTrialDuration) {
       clearTimeout(timerId);

--- a/task-launcher/src/tasks/shared/helpers/appTimer.ts
+++ b/task-launcher/src/tasks/shared/helpers/appTimer.ts
@@ -1,15 +1,34 @@
 import { taskStore } from '../../../taskStore';
+import { finishExperiment } from '../trials';
+import { PageStateHandler} from './PageStateHandler';
+
 // This feature allows the task configurator to set a time limit for the app,
 // configured via url and store variable maxTime.
 // Preload time is not included in the time limit
+
+// define timerId here so that it can be cleared if task ends early
+let timerId: any;
 
 export const startAppTimer = (maxTimeInMinutes: number, finishExperiment: () => void) => {
   // Minimum time is 1 minute
   const maxTimeInMilliseconds = Math.max(maxTimeInMinutes, 1) * 60000;
 
-  const timerId = setTimeout(() => {
+  taskStore('startTime', Date.now());
+
+  timerId = setTimeout(() => {
     taskStore('maxTimeReached', true);
     finishExperiment();
     clearTimeout(timerId);
   }, maxTimeInMilliseconds);
 };
+
+// function for ending the task if the next trial
+export async function checkEndTaskEarly(timeRemaining: number, stimAudio: string) {
+    const pageStateHandler = new PageStateHandler(stimAudio, false); 
+    const minTrialDuration = await pageStateHandler.getStimulusDurationMs() + 2000; 
+
+    if (timeRemaining < minTrialDuration) {
+      clearTimeout(timerId);
+      finishExperiment(); 
+    }
+  }

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -3,6 +3,7 @@ import { mediaAssets } from '../../..';
 import { camelize } from './camelize';
 import { taskStore } from '../../../taskStore';
 import { cat, jsPsych } from '../../taskSetup';
+import { checkEndTaskEarly } from './appTimer';
 
 // This function reads the corpus, calls the adaptive algorithm to select
 // the next item, stores it in a session variable, and removes it from the corpus
@@ -25,6 +26,13 @@ export const getStimulus = (corpusType: string, blockNumber?: number) => {
     // ends the setup timeline
     jsPsych.endCurrentTimeline();
   }
+
+  // end task if there is not enough time to display next stimulus
+  const maxTimeInMilliseconds = taskStore().maxTime * 60000; 
+  const timeElapsed = Date.now()  - taskStore().startTime; 
+  const timeRemaining = maxTimeInMilliseconds - timeElapsed; 
+ 
+  checkEndTaskEarly(timeRemaining, stimAudio); 
 
   // store the item for use in the trial
   taskStore('nextStimulus', itemSuggestion.nextStimulus);


### PR DESCRIPTION
This PR adds a check for the amount of time remaining during the fixation/setup trials and ends the task if there is not enough time to show the next stimulus. This is meant to prevent the abrupt switch to the end-of-task screen while the audio file is still playing for a trial. 