### PR TITLE
Read item-bank-translations csv from admin firebase projects

### DIFF
--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -59,7 +59,7 @@ export class TaskLauncher {
       await getCorpus(config, isDev);
     }
 
-    await getTranslations(config.language);
+    await getTranslations(isDev, config.language);
 
     return buildTaskTimeline(config, mediaAssets);
   }

--- a/task-launcher/src/tasks/shared/helpers/getTranslations.ts
+++ b/task-launcher/src/tasks/shared/helpers/getTranslations.ts
@@ -25,7 +25,7 @@ function parseTranslations(translationData: Record<string, string>[], configLang
   taskStore('translations', translations);
 }
 
-export const getTranslations = async (configLanguage?: string) => {
+export const getTranslations = async (isDev: boolean, configLanguage?: string) => {
   if (!configLanguage) {
     return;
   }
@@ -53,11 +53,15 @@ export const getTranslations = async (configLanguage?: string) => {
   }
 
   async function fetchData() {
-    const urls = [
-      // This will eventually be split into separate files
-      `https://storage.googleapis.com/road-dashboard/item-bank-translations.csv`,
-    ];
-
+    // This will eventually be split into separate files
+    let urls;
+    isDev ? 
+      urls = [
+        `https://storage.googleapis.com/levante-dashboard-dev/item-bank-translations.csv`
+      ] :
+      urls = [
+      ` https://storage.googleapis.com/levante-dashboard-prod/item-bank-translations.csv`
+      ]
     try {
       await parseCSVs(urls);
     } catch (error) {

--- a/task-launcher/src/tasks/shared/helpers/getTranslations.ts
+++ b/task-launcher/src/tasks/shared/helpers/getTranslations.ts
@@ -54,14 +54,9 @@ export const getTranslations = async (isDev: boolean, configLanguage?: string) =
 
   async function fetchData() {
     // This will eventually be split into separate files
-    let urls;
-    isDev ? 
-      urls = [
-        `https://storage.googleapis.com/levante-dashboard-dev/item-bank-translations.csv`
-      ] :
-      urls = [
-      ` https://storage.googleapis.com/levante-dashboard-prod/item-bank-translations.csv`
-      ]
+    const urls = [
+      `https://storage.googleapis.com/levante-dashboard-${isDev ? 'dev' : 'prod'}/item-bank-translations.csv`
+    ]
     try {
       await parseCSVs(urls);
     } catch (error) {


### PR DESCRIPTION
This PR switches to reading item-bank-translations.csv from the admin firebase projects (in the `levante-dashboard-dev` and `levante-dashboard-prod` buckets) rather than the road-dashboard bucket in `hs-levante-assessment-prod`.