### PR TITLE
Styling updates

### DIFF
--- a/task-launcher/src/styles/abstracts/_spacings.scss
+++ b/task-launcher/src/styles/abstracts/_spacings.scss
@@ -7,4 +7,6 @@ $lev-spacing-xs: 16px;
 $lev-spacing-xxs: 12px;
 $lev-spacing-xxxs: 8px;
 
-$lev-resized-buttons-2: calc(min(70vh, 90vw) / 2 - 10px);
+$adjusted-viewport: min(90vw, 90vh); 
+
+$lev-resized-buttons-2: calc(($adjusted-viewport * 0.70) / 2 - 10px);

--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -202,9 +202,9 @@ button {
     border: 2px solid $border-button-accent;
 
     @include respond-to('small') {
-      width: 48px;
-      height: 48px;
-      padding: 12px;
+      width: 36px;
+      height: 36px;
+      padding: 9px;
     }
 
     &:hover {

--- a/task-launcher/src/styles/layout/_containers.scss
+++ b/task-launcher/src/styles/layout/_containers.scss
@@ -153,7 +153,6 @@
   width: 100%;
   max-width: 900px;
   justify-content: center;
-  margin-top: calc($replay_btn_size + $replay_btn_pos);
   margin-bottom: 16px;
   align-items: center;
 

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -42,7 +42,7 @@ export const getLayoutConfig = (
       trialType === 'Non-symbolic Number Identification' || trialType === 'Non-symbolic Number Comparison'
         ? ['image-medium']
         : trialType === 'Counting'
-        ? []
+        ? ['primary']
         : ['secondary'];
     defaultConfig.response = {
       target: prepChoices.target,


### PR DESCRIPTION
This PR adjusts some styling to try to address the issues that Colombia is having. I resized the mental rotation buttons based on an `adjusted-viewport` variable, and removed an unnecessary top margin from the instructions. We could try resizing everything based on `adjusted-viewport`, but I went with the minimal change that might help for now.