### PR TITLE
Preload all media at start of task for CATs for now

### DIFF
--- a/task-launcher/src/tasks/matrix-reasoning/timeline.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/timeline.ts
@@ -81,7 +81,7 @@ export default function buildMatrixTimeline(config: Record<string, any>, mediaAs
   let currPreloadBatch = 0;
 
   const initialMedia = getLeftoverAssets(batchedMediaAssets, mediaAssets);
-  const initialPreload = createPreloadTrials(initialMedia).default;
+  const initialPreload = createPreloadTrials(runCat ? mediaAssets : initialMedia).default;
 
   const timeline = [initialPreload, initialTimeline, ...instructions];
 

--- a/task-launcher/src/tasks/mental-rotation/timeline.ts
+++ b/task-launcher/src/tasks/mental-rotation/timeline.ts
@@ -87,7 +87,7 @@ export default function buildMentalRotationTimeline(config: Record<string, any>,
   let currPreloadBatch = 0;
   const initialMedia = getLeftoverAssets(batchedMediaAssets, mediaAssets);
 
-  const initialPreload = createPreloadTrials(initialMedia).default;
+  const initialPreload = createPreloadTrials((runCat ? mediaAssets : initialMedia)).default;
 
   const timeline = [initialPreload, initialTimeline, imageInstructions, videoInstructionsMisfit, videoInstructionsFit];
 

--- a/task-launcher/src/tasks/trog/timeline.ts
+++ b/task-launcher/src/tasks/trog/timeline.ts
@@ -59,7 +59,7 @@ export default function buildTROGTimeline(config: Record<string, any>, mediaAsse
   // counter for next batch to preload (skipping the initial preload)
   let currPreloadBatch = 0;
 
-  const initialPreload = preloadSharedAudio();
+  const initialPreload = runCat ? createPreloadTrials(mediaAssets).default : preloadSharedAudio();
 
   const timeline = [initialPreload, initialTimeline];
 

--- a/task-launcher/src/tasks/vocab/timeline.ts
+++ b/task-launcher/src/tasks/vocab/timeline.ts
@@ -57,7 +57,8 @@ export default function buildVocabTimeline(config: Record<string, any>, mediaAss
   // counter for next batch to preload
   let currPreloadBatch = 0;
 
-  const initialPreload = preloadSharedAudio();
+  const initialPreload = runCat ? createPreloadTrials(mediaAssets).default : preloadSharedAudio();
+  console.log(initialPreload);
 
   // does not matter if trial has properties that don't belong to that type
   const trialConfig = {


### PR DESCRIPTION
This PR preloads all media assets at the beginning of the single-block CAT tasks (mental rotation, matrix reasoning, trog, and vocab), fixing a bug where nothing was being preloaded for CATs. 