### PR TITLE
Add fallback image for missing images

### DIFF
--- a/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
@@ -31,7 +31,7 @@ export const instructions = instructionData.map((data) => {
 
                  
                         <img
-                            src=${mediaAssets.images[data.image]}
+                            src=${mediaAssets.images[data.image] || mediaAssets.images.imageNotFoundFallback}
                             alt='Instruction graphic'
                         />
                     </div>`;

--- a/task-launcher/src/tasks/memory-game/trials/instructions.ts
+++ b/task-launcher/src/tasks/memory-game/trials/instructions.ts
@@ -61,12 +61,12 @@ export const instructions = instructionData.map((data) => {
                         </div>
                         <div class="lev-stim-content-x-3">
                             ${
-                              data.video
+                              data.video && mediaAssets.video[data.video]
                                 ? `<video class='instruction-video-small' autoplay loop>
                                     <source src=${mediaAssets.video[data.video]} type='video/mp4'>
                                 </video>`
                                 : `<img
-                                    src=${mediaAssets.images[data.image as string]}
+                                    src=${mediaAssets.images[data.image as string] || mediaAssets.images.imageNotFoundFallback}
                                     alt='Instruction graphic'
                                 />`
                             }

--- a/task-launcher/src/tasks/mental-rotation/trials/instructions.ts
+++ b/task-launcher/src/tasks/mental-rotation/trials/instructions.ts
@@ -36,10 +36,14 @@ export const videoInstructionsFit = {
         <button id="${replayButtonHtmlId}" class="replay">
           ${replayButtonSvg}
         </button>
-        <video class="instruction-video" autoplay>
-          <source src=${mediaAssets.video.mentalRotationExampleFit} type="video/mp4"/>
-          Your browser does not support the video tag.
-        </video>
+        ${
+          mediaAssets.video.mentalRotationExampleFit ? 
+          `<video class="instruction-video" autoplay>
+            <source src=${mediaAssets.video.mentalRotationExampleFit} type="video/mp4"/>
+            Your browser does not support the video tag.
+          </video>` :
+          `<img src=${mediaAssets.images.imageNotFoundFallback} class="instruction-video" />`
+        }
       </div>
     `;
   },
@@ -81,10 +85,14 @@ export const videoInstructionsMisfit = {
         <button id="${replayButtonHtmlId}" class="replay">
           ${replayButtonSvg}
         </button>
-        <video class="instruction-video" autoplay>
-          <source src=${mediaAssets.video.mentalRotationExampleMisfit} type="video/mp4"/>
-          Your browser does not support the video tag.
-        </video>
+        ${
+          mediaAssets.video.mentalRotationExampleMisfit ? 
+          `<video class="instruction-video" autoplay>
+            <source src=${mediaAssets.video.mentalRotationExampleMisfit} type="video/mp4"/>
+            Your browser does not support the video tag.
+          </video>` :
+          `<img src=${mediaAssets.images.imageNotFoundFallback} class="instruction-video" />`
+        }
       </div>
     `;
   },
@@ -123,7 +131,7 @@ export const imageInstructions = {
         <button id="${replayButtonHtmlId}" class="replay">
           ${replayButtonSvg}
         </button>
-        <img src=${mediaAssets.images.mentalRotationExample} class="instruction-video" />
+        <img src=${mediaAssets.images.mentalRotationExample || mediaAssets.images.imageNotFoundFallback} class="instruction-video" />
       </div>
     `;
   },


### PR DESCRIPTION
This PR closes #369, adding a fallback image in case the required image is not found (a short term fix for Colombia). I added this for the hardcoded images that are not in the task corpora, since any missing corpus images would cause the validation to fail and end the task with an error. 