### PR TITLE
Fixing intermittent audio issues

### DIFF
--- a/task-launcher/src/tasks/shared/helpers/audioHandler.ts
+++ b/task-launcher/src/tasks/shared/helpers/audioHandler.ts
@@ -47,21 +47,9 @@ export class PageAudioHandler {
 
     try {
       const jsPsychAudioCtx = jsPsych.pluginAPI.audioContext();
-      // Ensure the file exists and is audio; bail out gracefully otherwise
-      const headResp = await fetch(audioUri, { method: 'HEAD' }).catch(() => null);
-      if (!headResp || !headResp.ok) {
-        return; // skip playing missing audio
-      }
-      const ct = headResp.headers.get('content-type') || '';
-      if (!ct.startsWith('audio/')) {
-        return; // skip non-audio asset mistakenly referenced
-      }
 
       // Returns a promise of the AudioBuffer of the preloaded file path.
-      const audioBuffer = (await jsPsych.pluginAPI.getAudioBuffer(audioUri).catch(() => null)) as AudioBuffer | null;
-      if (!audioBuffer || typeof (audioBuffer as any).getChannelData !== 'function') {
-        return; // decode failed or not an AudioBuffer
-      }
+      const audioBuffer = await jsPsych.pluginAPI.getAudioBuffer(audioUri) as AudioBuffer | null;
 
       const audioSource: AudioBufferSourceNode = jsPsychAudioCtx.createBufferSource();
       PageAudioHandler.audioSource = audioSource;


### PR DESCRIPTION
We are making an extra head request before we play an audio which is not required because we establish the resource exists by listing out assets in the bucket prior to task launch. The extra code had a number of pathways that were silently failing and returning which stopped sentry from alerting us the actual issues.

This PR just reverts us back to our original state before these changes were put in.