### PR TITLE
Fix math ending early

### DIFF
--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -326,8 +326,8 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
         fullCorpus.start.forEach((trial) => timeline.push(stimulusBlock(trial)));
       }
 
-      const numOfTrials = allBlocks[i].length / trialProportionsPerBlock[i];
-      taskStore.transact('numOfTrials', (oldVal: number) => (oldVal += numOfTrials));
+      const numOfTrials = Math.floor(allBlocks[i].length / trialProportionsPerBlock[i]);
+      taskStore.transact('totalTestTrials', (oldVal: number) => (oldVal += numOfTrials));
       for (let j = 0; j < numOfTrials; j++) {
         timeline.push({ ...setupStimulusFromBlock(i), stimulus: '' }); // select only from the current block
         timeline.push(stimulusBlock());


### PR DESCRIPTION
This PR fixes a bug where completion was being recorded for the math CAT early, so a user could exit out after a few trials and it would show as completed. The wrong trial counter variable was being updated in the math timeline. Closes #380 