### PR TITLE
Fix assets-per-task.json always being read from dev

### DIFF
--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -74,7 +74,7 @@ export class TaskLauncher {
     }
 
     await getTranslations(isDev, config.language);
-    await getAssetsPerTask();
+    await getAssetsPerTask(isDev);
 
     const taskAudioAssetNames = [
       ...taskStore().assetsPerTask[taskName].audio,

--- a/task-launcher/src/tasks/shared/helpers/getAssetsPerTask.ts
+++ b/task-launcher/src/tasks/shared/helpers/getAssetsPerTask.ts
@@ -1,8 +1,10 @@
 import { taskStore } from '../../../taskStore';
 
-export async function getAssetsPerTask() {
+export async function getAssetsPerTask(isDev: boolean) {
   try {
-    const response = await fetch('https://storage.googleapis.com/levante-assets-dev/audio/assets-per-task.json');
+    const response = await fetch(
+      `https://storage.googleapis.com/levante-assets-${isDev ? "dev" : "prod"}/audio/assets-per-task.json`
+    );
 
     if (!response.ok) {
       throw new Error(`Error: ${response.status}`);


### PR DESCRIPTION
This PR fixes a bug where the assets-per-task.json file was always being read from the dev bucket, even when running on prod.