### PR TITLE
Add styling to fix button formatting issues on older ipads

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -61,6 +61,9 @@ button {
     font-size: $font-size-lm;
     width: 2.5 * $font-size-l;
     height: 2.5 * $font-size-l;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     @include respond-to('small-medium') {
       font-size: $font-size-ms;


### PR DESCRIPTION
This PR introduces a small change that fixes the text centering issue happening on some older ipads. I verified that the formatting is correct on one of the ipads with this change.