### PR TITLE
Theory of mind fake CAT updates

### DIFF
--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -45,7 +45,7 @@ const language = urlParams.get('lng');
 const pid = urlParams.get('pid');
 const inferenceNumStories =
   urlParams.get('inferenceNumStories') === null ? null : parseInt(urlParams.get('inferenceNumStories'), 10);
-const numberOfStories = urlParams.get('numberOfStories') === null ? 3 : parseInt(urlParams.get('numberOfStories'), 10);
+const numberOfStories = urlParams.get('numberOfStories') === null ? 4 : parseInt(urlParams.get('numberOfStories'), 10);
 const semThreshold = Number(urlParams.get('semThreshold') || '0');
 const startingTheta = Number(urlParams.get('theta') || '0');
 // `taskVersion` is deprecated; prefer `version` when both are present.

--- a/task-launcher/src/tasks/shared/helpers/addAudioKeyFallbacks.ts
+++ b/task-launcher/src/tasks/shared/helpers/addAudioKeyFallbacks.ts
@@ -1,0 +1,42 @@
+// falls back to non gender specific audio key if gender specific audio key is not present
+export function addAudioKeyFallbacks(layoutConfig: LayoutConfigType, mediaAssets: MediaAssetsType) {
+    const fallbackValues: string[] = [];
+    const fallbackDisplayValues: string[] = [];
+    if (layoutConfig.isStaggered) {
+        layoutConfig.response.values.forEach((value) => {
+            if (
+                (value.endsWith('-plural') || value.endsWith('-fem')) &&
+                !mediaAssets.audio[value]
+            ) {
+                fallbackValues.push(value.replace('-plural', '').replace('-fem', ''));
+            } else {
+                fallbackValues.push(value);
+            }
+        });
+
+        layoutConfig.response.displayValues.forEach((value) => {
+            if (
+                (value.endsWith('-plural') || value.endsWith('-fem')) &&
+                !mediaAssets.audio[value]
+            ) {
+                fallbackDisplayValues.push(value.replace('-plural', '').replace('-fem', ''));
+            } else {
+                fallbackDisplayValues.push(value);
+            }
+        });
+
+        let target = layoutConfig.response.target;
+        if (
+            (target.endsWith('-plural') || target.endsWith('-fem')) &&
+            !mediaAssets.audio[target]
+        ) {
+            target = target.replace('-plural', '').replace('-fem', '');
+        }
+        
+        layoutConfig.response.target = target;
+        layoutConfig.response.values = fallbackValues; 
+        layoutConfig.response.displayValues = fallbackDisplayValues;
+    }
+
+    return layoutConfig;
+}

--- a/task-launcher/src/tasks/shared/helpers/config.ts
+++ b/task-launcher/src/tasks/shared/helpers/config.ts
@@ -123,7 +123,7 @@ export const setSharedConfig = async (
     cat: !!cat, // defaults to false
     heavyInstructions: !!heavyInstructions,
     inferenceNumStories: Number(inferenceNumStories) || undefined,
-    numberOfStories: Number(numberOfStories) || 3,
+    numberOfStories: Number(numberOfStories) || 4,
     semThreshold: Number(semThreshold),
     startingTheta: Number(startingTheta),
     demoMode: !!demoMode,

--- a/task-launcher/src/tasks/theory-of-mind/helpers/config.ts
+++ b/task-launcher/src/tasks/theory-of-mind/helpers/config.ts
@@ -6,6 +6,7 @@ import {
   mapDistractorsToString,
 } from '../../shared/helpers';
 import { taskStore } from '../../../taskStore';
+import { addAudioKeyFallbacks } from '../../shared/helpers/addAudioKeyFallbacks';
 
 type GetConfigReturnType = {
   itemConfig: LayoutConfigType;
@@ -46,10 +47,11 @@ export const getLayoutConfig = (
 
   defaultConfig.blockedTrials = taskStore().version === 2 && !fillerTrialIds.includes(stimulus.itemId);
 
-  const messages = validateLayoutConfig(defaultConfig, mediaAssets, translations, stimulus);
+  const updatedConfig = addAudioKeyFallbacks(defaultConfig, mediaAssets);
+  const messages = validateLayoutConfig(updatedConfig, mediaAssets, translations, stimulus);
 
   return {
-    itemConfig: defaultConfig,
+    itemConfig: updatedConfig,
     errorMessages: messages,
   };
 };


### PR DESCRIPTION
Updates the default number of stories in the task to 4 and adds a fallback for any gender/number specific audio assets ending in -fem or -plural.