### PR TITLE
Publish sourcemap

### DIFF
--- a/task-launcher/package-lock.json
+++ b/task-launcher/package-lock.json
@@ -39,7 +39,6 @@
         "@rollup/plugin-dsv": "^3.0.2",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
-        "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/fscreen": "^1.0.4",
         "@types/lodash": "^4.17.7",
@@ -3546,28 +3545,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
-      "dev": true,
-      "dependencies": {
-        "serialize-javascript": "^6.0.1",
-        "smob": "^1.0.0",
-        "terser": "^5.17.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -21158,12 +21135,6 @@
         "node": "*"
       }
     },
-    "node_modules/smob": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
-      "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
-      "dev": true
-    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -23041,6 +23012,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vm-browserify": {

--- a/task-launcher/package.json
+++ b/task-launcher/package.json
@@ -68,7 +68,6 @@
     "@rollup/plugin-dsv": "^3.0.2",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
-    "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/fscreen": "^1.0.4",
     "@types/lodash": "^4.17.7",

--- a/task-launcher/rollup.config.js
+++ b/task-launcher/rollup.config.js
@@ -1,7 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import dsv from '@rollup/plugin-dsv';
 import json from '@rollup/plugin-json';
-import terser from '@rollup/plugin-terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 import typescript from '@rollup/plugin-typescript';
@@ -18,7 +17,6 @@ export default {
     nodeResolve({
       preferBuiltins: true,
     }),
-    terser(),
     commonjs(),
   ],
   output: [
@@ -28,6 +26,7 @@ export default {
       entryFileNames: '[name].[hash].js',
       chunkFileNames: '[name].[hash].js',
       format: 'es',
+      sourcemap: true,
     },
   ],
 };


### PR DESCRIPTION
Stacktraces in sentry logs are unusable in their current form. Since this is a library, not a standalone app, we should publish this unminified and let the consuming app handle that.

- Remove terser minification/obfuscation (to be handled by dashboard build pipeline)
- Publish sourcemap (dashboard build pipeline must chain it w/ its own sourcemaps)