### PR TITLE
Hearts and flowers updates

### DIFF
--- a/task-launcher/cypress/e2e/hearts_and_flowers.cy.js
+++ b/task-launcher/cypress/e2e/hearts_and_flowers.cy.js
@@ -1,4 +1,5 @@
 const hearts_and_flowers_url = 'http://localhost:8080/?task=hearts-and-flowers';
+const hearts_and_flowers_v2_url = 'http://localhost:8080/?task=hearts-and-flowers&version=2';
 
 // keep track of game phase (true means it has started)
 let heart_phase = false;
@@ -8,6 +9,14 @@ let final_instructions = false; // instructions before final mixed test phase
 let mixed_test = false;
 
 describe('test hearts and flowers', () => {
+  beforeEach(() => {
+    heart_phase = false;
+    flower_phase = false;
+    mixed_practice = false;
+    final_instructions = false;
+    mixed_test = false;
+  });
+
   it('visits hearts and flowers and plays game', () => {
     cy.visit(hearts_and_flowers_url);
 
@@ -17,23 +26,31 @@ describe('test hearts and flowers', () => {
 
     hafLoop();
   });
+
+  it('visits hearts and flowers v2 and plays game', () => {
+    cy.visit(hearts_and_flowers_v2_url);
+
+    cy.contains('OK', { timeout: 300000 }).should('be.visible');
+    cy.contains('OK').realClick(); // start fullscreen
+
+    hafLoop(true);
+  });
 });
 
-function hafLoop() {
+function hafLoop(isV2 = false) {
   // end if the there are no elements inside jspsych content
   cy.get('.jspsych-content').then((content) => {
     if (content.children().length) {
       // wait for feedback screen to go away
       cy.get('.haf-cr-container').should('not.exist');
-      const okButton = content.find('.primary');
 
       // Make the decision here to handle instructions or pick an answer
-      if (okButton.length) {
-        handleInstructions();
+      if (isInstructionScreen(content, isV2)) {
+        handleInstructions(isV2);
       } else {
-        pickAnswer();
+        pickAnswer(isV2);
       }
-      hafLoop();
+      hafLoop(isV2);
     } else {
       // make sure that the game has progressed through major phases before passing
       assert.isTrue(heart_phase && flower_phase && mixed_test);
@@ -41,21 +58,101 @@ function hafLoop() {
   });
 }
 
-function handleInstructions() {
+function isInstructionScreen(content, isV2) {
+  if (content.find('.primary:visible').length) {
+    return true;
+  }
+
+  if (!isV2) {
+    return false;
+  }
+
+  return content.find('#instruction-text').length > 0 && !content.find('.haf-stimulus-holder').length;
+}
+
+function handleInstructions(isV2 = false) {
   cy.get('.jspsych-content').then((content) => {
-    const okButton = content.find('.primary');
+    const okButton = content.find('.primary:visible');
 
     if (okButton.length) {
       cy.contains('OK').realClick();
-
       final_instructions = mixed_practice;
+      return;
     }
+
+    if (!isV2) {
+      return;
+    }
+
+    if (content.find('#instruction-text').length && content.find('.lev-response-row').length) {
+      handleV2ResponseButtonDemo();
+      return;
+    }
+
+    continueV2Instruction();
+    final_instructions = mixed_practice;
   });
 
   return;
 }
 
-function pickAnswer() {
+function handleV2ResponseButtonDemo() {
+  cy.get('.lev-response-row .secondary--green', { timeout: 120000 })
+    .filter(':not([style*="visibility: hidden"])')
+    .first()
+    .should(($button) => {
+      expect($button[0].style.animation).to.include('pulse');
+    })
+    .then(($button) => {
+      cy.get('.lev-response-row .secondary--green').then(($buttons) => {
+        const visibleIndex = [...$buttons].findIndex(
+          (button) => button.style.visibility !== 'hidden' && !button.disabled,
+        );
+
+        cy.get('body').then(($body) => {
+          if ($body.find('.arrow-key-border').length) {
+            cy.realPress(visibleIndex === 0 ? 'ArrowLeft' : 'ArrowRight');
+          } else {
+            cy.wrap($button).realClick();
+          }
+        });
+      });
+    });
+
+  // instruction demo trials wait before advancing
+  cy.wait(2500);
+}
+
+function continueV2Instruction(retryCount = 0) {
+  if (retryCount > 30) {
+    throw new Error('Failed to advance v2 instruction trial');
+  }
+
+  cy.get('.jspsych-content').then(($content) => {
+    if (!$content.find('#instruction-text').length) {
+      return;
+    }
+
+    const instructionText = $content.find('#instruction-text').text();
+
+    cy.wait(3000);
+    cy.realPress(' ');
+    cy.wait(1000);
+
+    cy.get('.jspsych-content').then(($nextContent) => {
+      const stillOnSameTrial =
+        $nextContent.find('#instruction-text').length &&
+        $nextContent.find('#instruction-text').text() === instructionText &&
+        !$nextContent.find('.haf-stimulus-holder').length;
+
+      if (stillOnSameTrial) {
+        continueV2Instruction(retryCount + 1);
+      }
+    });
+  });
+}
+
+function pickAnswer(isV2 = false) {
   // wait for feedback screen to end
   cy.get('.haf-stimulus-holder').should('exist');
 
@@ -72,8 +169,14 @@ function pickAnswer() {
       // get stimulus image itself and then click button based on src and pos
       const stim = cy.get('[alt="heart or flower"]');
       stim.invoke('attr', 'src').then((src) => {
-        // click the correct button
-        cy.get('.secondary--green').eq(getCorrectButtonIdx(src, pos)).realClick();
+        if (isV2) {
+          // press the correct arrow key
+          const index = getCorrectButtonIdx(src, pos);
+          cy.realPress(index === 0 ? 'ArrowLeft' : 'ArrowRight');
+        } else {
+          // click the correct button
+          cy.get('.secondary--green').eq(getCorrectButtonIdx(src, pos)).realClick();
+        }
       });
     }
   });

--- a/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
@@ -5,7 +5,9 @@ export function setupHafMultiResponseTouchRouting() {
   toast.id = 'lev-toast-default';
   toast.classList.add('lev-toast-default');
   toast.textContent = taskStore().translations.heartsAndFlowersClickReminder;
-  document.body.appendChild(toast);
+  if (!taskStore().inputCapability.touch) {
+    document.body.appendChild(toast);
+  }
 
   document.querySelectorAll('.jspsych-html-multi-response-button').forEach((wrapper) => {
     if (wrapper.dataset.hafTouchRouting === '1') return;
@@ -42,6 +44,10 @@ export function setupHafMultiResponseTouchRouting() {
 
 let timeoutID;
 function triggerToast() {
+  if (taskStore().inputCapability.touch) {
+    return;
+  }
+  
   const toast = document.getElementById('lev-toast-default');
 
   if (toast && !toast.classList.contains('show')) {

--- a/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
@@ -47,7 +47,7 @@ function triggerToast() {
   if (taskStore().inputCapability.touch) {
     return;
   }
-  
+
   const toast = document.getElementById('lev-toast-default');
 
   if (toast && !toast.classList.contains('show')) {

--- a/task-launcher/src/tasks/hearts-and-flowers/helpers/utils.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/helpers/utils.js
@@ -118,4 +118,4 @@ export const getInputInstructPrompt = (showButton = false) => {
   } else {
     return inputCapability?.touch ? 'heartsAndFlowersInstructTouchscreen' : 'heartsAndFlowersInstructKeyboard';
   }
-};    
+};

--- a/task-launcher/src/tasks/hearts-and-flowers/helpers/utils.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/helpers/utils.js
@@ -110,8 +110,12 @@ export const getStimulusLayout = (imageSrc, isLeft, promptText = undefined, repl
   return template;
 };
 
-export const getInputInstructPrompt = () => {
+export const getInputInstructPrompt = (showButton = false) => {
   const inputCapability = taskStore().inputCapability;
 
-  return inputCapability?.touch ? 'heartsAndFlowersInstructTouchscreen' : 'heartsAndFlowersInstructKeyboard';
-};
+  if (showButton) {
+    return inputCapability?.touch ? 'heartsAndFlowersInstructButtonTouch' : 'heartsAndFlowersInstructKeyPress';
+  } else {
+    return inputCapability?.touch ? 'heartsAndFlowersInstructTouchscreen' : 'heartsAndFlowersInstructKeyboard';
+  }
+};    

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -90,7 +90,7 @@ export default function buildHeartsAndFlowersTimeline(config, mediaAssets) {
   let timeline = [preloadTrials, initialTimeline];
   if (hfV2) {
     timeline.push(getInputInstructions());
-    timeline.push(getLeftButtonDemo()); 
+    timeline.push(getLeftButtonDemo());
     timeline.push(getRightButtonDemo());
   }
 

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -24,6 +24,8 @@ import {
   getEndGame,
   getInputInstructions,
   getGoingFasterInstructions,
+  getLeftButtonDemo,
+  getRightButtonDemo,
 } from './trials/instructions';
 import { StimulusType, StimulusSideType, AssessmentStageType, CorpusTrialType } from './helpers/utils';
 
@@ -88,6 +90,8 @@ export default function buildHeartsAndFlowersTimeline(config, mediaAssets) {
   let timeline = [preloadTrials, initialTimeline];
   if (hfV2) {
     timeline.push(getInputInstructions());
+    timeline.push(getLeftButtonDemo()); 
+    timeline.push(getRightButtonDemo());
   }
 
   if (timelineAdminConfig.heart) {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
@@ -14,6 +14,7 @@ import { disableOkButton } from '../../shared/helpers/disableOkButton';
 import { enableOkButton } from '../../shared/helpers/enableButtons';
 
 let continueTrialConfig;
+let cleanupInstructionInputListeners = [];
 
 function isHfV2() {
   return taskStore().version === 2;
@@ -77,7 +78,6 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
   }
 
   const replayButtonHtmlId = 'replay-btn-revisited';
-  let cleanupInstructionInputListeners = null;
 
   const trial = {
     type: jsPsychHtmlMultiResponse,
@@ -184,12 +184,16 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
                   maxRepetitions: 2
                 },
                 onEnded: () => {
-                  window.addEventListener('keydown', (event) => {
+                  const onSpacebarPress = (event) => {
                     if (event.key === " ") {
                       jsPsych.finishTrial();
                     }
-                  }, 
-                  {once: true});
+                  };
+      
+                  window.addEventListener('keydown', onSpacebarPress);
+                  cleanupInstructionInputListeners.push(() => {
+                    window.removeEventListener('keydown', onSpacebarPress);
+                  });
                 }
               }
 
@@ -212,18 +216,18 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
             }
 
             displayedButton.addEventListener('touchend', buttonPressListener);
-            cleanupInstructionInputListeners = () => {
-              displayedButton.removeEventListener('touchend', onButtonPress);
-            };
+            cleanupInstructionInputListeners.push(() => {
+              displayedButton.removeEventListener('touchend', buttonPressListener);
+            });
           } else {
             const onWindowKeydown = (event) => {
               onButtonPress(displayedButton, displayedButtonIndex, event);
             };
 
             window.addEventListener('keydown', onWindowKeydown);
-            cleanupInstructionInputListeners = () => {
+            cleanupInstructionInputListeners.push(() => {
               window.removeEventListener('keydown', onWindowKeydown);
-            };
+            });
           }
         },
       };
@@ -235,8 +239,10 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
       setupReplayAudio(pageStateHandler);
     },
     on_finish: () => {
-      cleanupInstructionInputListeners?.();
-      cleanupInstructionInputListeners = null;
+      cleanupInstructionInputListeners?.forEach((listenerCleanup) => {
+        listenerCleanup?.();
+      });
+      cleanupInstructionInputListeners = [];
 
       PageAudioHandler.stopAndDisconnectNode();
 

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
@@ -136,10 +136,10 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
         buttonContainer.classList.add('linear-4');
         buttonContainer.innerHTML = `
           <div class='response-container--small'>
-            <button class='secondary--green' ${buttonSide === "right" ? 'style=visibility: hidden disabled' : ''}></button>
+            <button class='secondary--green' ${buttonSide === "right" ? 'style="visibility: hidden" disabled' : ''}></button>
           </div>
           <div class='response-container--small'>
-            <button class='secondary--green' ${buttonSide === "left" ? 'style=visibility: hidden disabled' : ''}></button>
+            <button class='secondary--green' ${buttonSide === "left" ? 'style="visibility: hidden" disabled' : ''}></button>
           </div>`;
 
         const stimContainer = document.querySelector('.lev-stimulus-container');
@@ -207,13 +207,14 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
           addKeyHelpers(displayedButton, displayedButtonIndex);
 
           if (taskStore().inputCapability?.touch) {
-            displayedButton.addEventListener(
-              'touchend',
-              (event) => {
-                onButtonPress(displayedButton, displayedButtonIndex, event);
-              },
-              { once: true },
-            );
+            const buttonPressListener = (event) => {
+              onButtonPress(displayedButton, displayedButtonIndex, event);
+            }
+
+            displayedButton.addEventListener('touchend', buttonPressListener);
+            cleanupInstructionInputListeners = () => {
+              displayedButton.removeEventListener('touchend', onButtonPress);
+            };
           } else {
             const onWindowKeydown = (event) => {
               onButtonPress(displayedButton, displayedButtonIndex, event);
@@ -230,7 +231,7 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
       const promptAudioKey = showResponseButton ? getPromptKey(true) : getPromptKey(false);
       PageAudioHandler.playAudio(mediaAssets.audio[promptAudioKey] || mediaAssets.audio.inputAudioCue, audioConfig);
 
-      const pageStateHandler = new PageStateHandler(getPromptKey());
+      const pageStateHandler = new PageStateHandler(promptAudioKey);
       setupReplayAudio(pageStateHandler);
     },
     on_finish: () => {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
@@ -57,10 +57,18 @@ export function getEndGame() {
 }
 
 export function getInputInstructions() {
-  return buildInstructionTrial(mediaAssets.images.animalBodySq, getInputInstructPrompt, true);
+  return buildInstructionTrial(mediaAssets.images.animalBodySq, getInputInstructPrompt);
 }
 
-function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = false) {
+export function getLeftButtonDemo() {
+  return buildInstructionTrial(mediaAssets.images.animalBodySq, getInputInstructPrompt, true, 'left');
+}
+
+export function getRightButtonDemo() {
+  return buildInstructionTrial(mediaAssets.images.animalBodySq, getInputInstructPrompt, true, 'right');
+}
+
+function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = false, buttonSide = null) {
   if (!mascotImage) {
     console.error(`buildInstructionTrial: Missing mascot image`);
   }
@@ -79,8 +87,8 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
         type: taskStore().inputCapability?.touch || !isHfV2() ? 'button' : 'bottomText',
         text:
           taskStore().inputCapability?.touch || !isHfV2()
-            ? taskStore().translations.continueButtonText
-            : taskStore().translations.heartsAndFlowersPressAnyKey,
+            ? "continueButtonText"
+            : "heartsAndFlowersPressAnyKey",
       };
 
       return `
@@ -89,7 +97,7 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
               ${replayButtonSvg}
             </button>
             <div id="instruction-text" class="lev-row-container instruction-small">
-              <p>${taskStore().translations[getPromptKey()]}</p>
+              <p>${taskStore().translations[showResponseButton ? getPromptKey(true) : getPromptKey()]}</p>
             </div>
             <div class="lev-stim-content-x-3">
               <img
@@ -99,8 +107,8 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
             </div>
             ${
               continueTrialConfig.type === 'bottomText'
-                ? `<div class="lev-row-container header" ${showResponseButtons ? 'style="display: none;"' : ''}><p>${
-                    continueTrialConfig.text
+                ? `<div class="lev-row-container header" ${showResponseButton ? 'style="display: none;"' : ''}><p>${
+                    taskStore().translations[continueTrialConfig.text]
                   }</p></div>`
                 : ''
             }
@@ -108,16 +116,15 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
         `;
     },
     prompt_above_buttons: true,
-    keyboard_choices: showResponseButtons ? 'NO_KEYS' : 'ALL_KEYS',
-    button_choices: () => (continueTrialConfig.type === 'button' ? [continueTrialConfig.text] : undefined),
+    keyboard_choices: 'NO_KEYS',
+    button_choices: () => (continueTrialConfig.type === 'button' ? [taskStore().translations[continueTrialConfig.text]] : undefined),
     button_html: () =>
-      continueTrialConfig.type === 'button' ? [`<button class="primary">%choice%</button>`] : undefined,
+      continueTrialConfig.type === 'button' ? [`<button class="primary" disabled>%choice%</button>`] : undefined,
     on_load: () => {
       let responseButtons;
       let onButtonPress;
-      let currentButtonToPress = 0;
 
-      if (showResponseButtons) {
+      if (showResponseButton) {
         if (continueTrialConfig.type === 'button') {
           disableOkButton();
           const okButton = document.querySelector('.primary');
@@ -129,10 +136,10 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
         buttonContainer.classList.add('linear-4');
         buttonContainer.innerHTML = `
           <div class='response-container--small'>
-            <button class='secondary--green'></button>
+            <button class='secondary--green' ${buttonSide === "right" ? 'style=visibility: hidden disabled' : ''}></button>
           </div>
           <div class='response-container--small'>
-            <button class='secondary--green'></button>
+            <button class='secondary--green' ${buttonSide === "left" ? 'style=visibility: hidden disabled' : ''}></button>
           </div>`;
 
         const stimContainer = document.querySelector('.lev-stimulus-container');
@@ -144,74 +151,74 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
           if (
             ((i === 0 && event.key === 'ArrowLeft') ||
               (i === 1 && event.key === 'ArrowRight') ||
-              event.type === 'touchend') &&
-            currentButtonToPress === i
+              event.type === 'touchend')
           ) {
             PageAudioHandler.playAudio(mediaAssets.audio.coin);
             button.classList.add('info-shadow');
             setTimeout(() => {
               button.classList.remove('info-shadow');
             }, 2000);
+
             button.style.animation = 'none';
-
-            currentButtonToPress++;
-            if (currentButtonToPress < responseButtons.length) {
-              responseButtons[currentButtonToPress].style.animation = 'pulse 2s infinite';
-            } else {
-              buttonContainer.style.display = 'none';
-
-              if (continueTrialConfig.type === 'bottomText') {
-                const bottomText = document.querySelector('.lev-row-container.header');
-                bottomText.style.display = 'block';
-
-                window.addEventListener(
-                  'keydown',
-                  () => {
-                    jsPsych.finishTrial();
-                  },
-                  { once: true },
-                );
-              } else {
-                const okButton = document.querySelector('.primary');
-                okButton.style.display = 'block';
-                enableOkButton();
-              }
-            }
+            buttonContainer.style.visibility = 'hidden';
+            setTimeout(() => {
+              jsPsych.finishTrial();
+            }, 2000);
           }
-        };
-      }
+        }
+      };
 
       const audioConfig = {
         restrictRepetition: {
           enabled: false,
           maxRepetitions: 2,
         },
-        onEnded: () => {
-          if (!showResponseButtons) {
+        onEnded: () => {   
+          if (!showResponseButton) {
+            if (continueTrialConfig.type === 'bottomText') {
+              const audioUri = mediaAssets.audio[continueTrialConfig.text];
+
+              const secondAudioConfig = {
+                restrictRepetition: {
+                  enabled: false,
+                  maxRepetitions: 2
+                },
+                onEnded: () => {
+                  window.addEventListener('keydown', (event) => {
+                    if (event.key === " ") {
+                      jsPsych.finishTrial();
+                    }
+                  }, 
+                  {once: true});
+                }
+              }
+
+              PageAudioHandler.playAudio(audioUri, secondAudioConfig);
+            } else {
+              enableOkButton();
+            }
+
             return;
           }
 
-          responseButtons[0].style.animation = 'pulse 2s infinite';
-          responseButtons.forEach((button, i) => {
-            addKeyHelpers(button, i);
-          });
+          const displayedButtonIndex = buttonSide === 'left' ? 0 : 1;
+          const displayedButton = responseButtons[displayedButtonIndex];
+          displayedButton.style.animation = 'pulse 1s infinite';
+          addKeyHelpers(displayedButton, displayedButtonIndex);
 
           if (taskStore().inputCapability?.touch) {
-            responseButtons.forEach((button, i) => {
-              button.addEventListener(
-                'touchend',
-                (event) => {
-                  onButtonPress(button, i, event);
-                },
-                { once: true },
-              );
-            });
+            displayedButton.addEventListener(
+              'touchend',
+              (event) => {
+                onButtonPress(displayedButton, displayedButtonIndex, event);
+              },
+              { once: true },
+            );
           } else {
             const onWindowKeydown = (event) => {
-              const i = currentButtonToPress;
-              if (i >= responseButtons.length) return;
-              onButtonPress(responseButtons[i], i, event);
+              onButtonPress(displayedButton, displayedButtonIndex, event);
             };
+
             window.addEventListener('keydown', onWindowKeydown);
             cleanupInstructionInputListeners = () => {
               window.removeEventListener('keydown', onWindowKeydown);
@@ -220,7 +227,8 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButtons = 
         },
       };
 
-      PageAudioHandler.playAudio(mediaAssets.audio[getPromptKey()] || mediaAssets.audio.inputAudioCue, audioConfig);
+      const promptAudioKey = showResponseButton ? getPromptKey(true) : getPromptKey(false);
+      PageAudioHandler.playAudio(mediaAssets.audio[promptAudioKey] || mediaAssets.audio.inputAudioCue, audioConfig);
 
       const pageStateHandler = new PageStateHandler(getPromptKey());
       setupReplayAudio(pageStateHandler);

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
@@ -85,10 +85,7 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
       // set the continue trial config based on the input capability
       continueTrialConfig = {
         type: taskStore().inputCapability?.touch || !isHfV2() ? 'button' : 'bottomText',
-        text:
-          taskStore().inputCapability?.touch || !isHfV2()
-            ? "continueButtonText"
-            : "heartsAndFlowersPressAnyKey",
+        text: taskStore().inputCapability?.touch || !isHfV2() ? 'continueButtonText' : 'heartsAndFlowersPressAnyKey',
       };
 
       return `
@@ -117,7 +114,8 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
     },
     prompt_above_buttons: true,
     keyboard_choices: 'NO_KEYS',
-    button_choices: () => (continueTrialConfig.type === 'button' ? [taskStore().translations[continueTrialConfig.text]] : undefined),
+    button_choices: () =>
+      continueTrialConfig.type === 'button' ? [taskStore().translations[continueTrialConfig.text]] : undefined,
     button_html: () =>
       continueTrialConfig.type === 'button' ? [`<button class="primary" disabled>%choice%</button>`] : undefined,
     on_load: () => {
@@ -136,10 +134,14 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
         buttonContainer.classList.add('linear-4');
         buttonContainer.innerHTML = `
           <div class='response-container--small'>
-            <button class='secondary--green' ${buttonSide === "right" ? 'style="visibility: hidden" disabled' : ''}></button>
+            <button class='secondary--green' ${
+              buttonSide === 'right' ? 'style="visibility: hidden" disabled' : ''
+            }></button>
           </div>
           <div class='response-container--small'>
-            <button class='secondary--green' ${buttonSide === "left" ? 'style="visibility: hidden" disabled' : ''}></button>
+            <button class='secondary--green' ${
+              buttonSide === 'left' ? 'style="visibility: hidden" disabled' : ''
+            }></button>
           </div>`;
 
         const stimContainer = document.querySelector('.lev-stimulus-container');
@@ -149,9 +151,9 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
 
         onButtonPress = (button, i, event) => {
           if (
-            ((i === 0 && event.key === 'ArrowLeft') ||
-              (i === 1 && event.key === 'ArrowRight') ||
-              event.type === 'touchend')
+            (i === 0 && event.key === 'ArrowLeft') ||
+            (i === 1 && event.key === 'ArrowRight') ||
+            event.type === 'touchend'
           ) {
             PageAudioHandler.playAudio(mediaAssets.audio.coin);
             button.classList.add('info-shadow');
@@ -165,15 +167,15 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
               jsPsych.finishTrial();
             }, 2000);
           }
-        }
-      };
+        };
+      }
 
       const audioConfig = {
         restrictRepetition: {
           enabled: false,
           maxRepetitions: 2,
         },
-        onEnded: () => {   
+        onEnded: () => {
           if (!showResponseButton) {
             if (continueTrialConfig.type === 'bottomText') {
               const audioUri = mediaAssets.audio[continueTrialConfig.text];
@@ -181,21 +183,21 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
               const secondAudioConfig = {
                 restrictRepetition: {
                   enabled: false,
-                  maxRepetitions: 2
+                  maxRepetitions: 2,
                 },
                 onEnded: () => {
                   const onSpacebarPress = (event) => {
-                    if (event.key === " ") {
+                    if (event.key === ' ') {
                       jsPsych.finishTrial();
                     }
                   };
-      
+
                   window.addEventListener('keydown', onSpacebarPress);
                   cleanupInstructionInputListeners.push(() => {
                     window.removeEventListener('keydown', onSpacebarPress);
                   });
-                }
-              }
+                },
+              };
 
               PageAudioHandler.playAudio(audioUri, secondAudioConfig);
             } else {
@@ -213,7 +215,7 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
           if (taskStore().inputCapability?.touch) {
             const buttonPressListener = (event) => {
               onButtonPress(displayedButton, displayedButtonIndex, event);
-            }
+            };
 
             displayedButton.addEventListener('touchend', buttonPressListener);
             cleanupInstructionInputListeners.push(() => {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
@@ -139,6 +139,7 @@ export function stimulus(isPractice, stage, trialType, stimulusDuration, onTrial
         response: response === 0 ? ResponseSideType.Left : ResponseSideType.Right,
         responseLocation: response,
         itemUid: itemUid,
+        presentationTime: hfV2 ? stimulusDuration : null,
       });
 
       taskStore.transact('testTrialCount', (oldVal) => oldVal + 1);


### PR DESCRIPTION
This PR makes the updates to hearts and flowers request in this [document](https://docs.google.com/document/d/1eTbX2tgxnAOJIwZ0qZGLZCHPhhok6MNlcdmQdyvD10c/edit?usp=sharing). The demo that lets the child practice using the buttons is now broken up into multiple trials, and the "press the spacebar to continue" text now has accompanying audio for desktop users. For touch screen users, the toast warning against using a mouse is disabled and the ok button to advance to the next trial is not enabled until the instructions are finished playng.