### PR TITLE
fix: noDoubleEquals and easy lint warnings (#466)

### DIFF
--- a/task-launcher/cypress/e2e/same_different.cy.js
+++ b/task-launcher/cypress/e2e/same_different.cy.js
@@ -21,7 +21,7 @@ function cleanDimensions(dimensions) {
   }
 
   const nonWhiteBackgrounds = ['gray', 'black', 'striped'];
-  if (checkOverlap(dimensions, nonWhiteBackgrounds).length == 0 && phaseCount > 3) {
+  if (checkOverlap(dimensions, nonWhiteBackgrounds).length === 0 && phaseCount > 3) {
     dimensions.push('white');
   }
 
@@ -77,7 +77,7 @@ function multiAfc() {
   cy.get('.jspsych-content').then((content) => {
     const responseButtons = content.find('img');
     const correctAnswer = content.find('.correct'); // correct flag signals a single afc trial
-    if (responseButtons.length == 0 || correctAnswer.length > 0) {
+    if (responseButtons.length === 0 || correctAnswer.length > 0) {
       return;
     }
     if (numSelections >= responseButtons.length - 1 || phaseCount < responseButtons.length) {
@@ -102,7 +102,7 @@ function multiAfc() {
           return !matchedDimensions.includes(dimension);
         });
 
-        if (validMatches.length > 0 && j != i) {
+        if (validMatches.length > 0 && j !== i) {
           matchedDimensions.push(validMatches[0]); // remember the matched dimension
           responseButtons[i].click();
           responseButtons[j].click();

--- a/task-launcher/cypress/e2e/same_different.cy.js
+++ b/task-launcher/cypress/e2e/same_different.cy.js
@@ -16,7 +16,7 @@ function cleanDimensions(dimensions) {
     dimensions.shift(); // ignore size dimension
   }
 
-  if (dimensions.every((element) => isNaN(Number(element))) && phaseCount > 3) {
+  if (dimensions.every((element) => Number.isNaN(Number(element))) && phaseCount > 3) {
     dimensions.push('1');
   }
 

--- a/task-launcher/postBuildPackage.js
+++ b/task-launcher/postBuildPackage.js
@@ -1,6 +1,6 @@
 // Updates the package.json after building the package.
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const outputDir = 'lib';
 

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
@@ -122,7 +122,7 @@ export function stimulus(isPractice, stage, trialType, stimulusDuration, onTrial
 
         const maxIncorrect = taskStore().maxIncorrect;
 
-        if (taskStore().numIncorrect == maxIncorrect) {
+        if (taskStore().numIncorrect === maxIncorrect) {
           finishExperiment();
         }
       }

--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -212,10 +212,10 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     const allCorpusParts = prepareCorpus(corpus, true, downexCorpus);
     const olderKidInstructionPractice: StimulusType[] = allCorpusParts.ipLight;
     const olderKidInstructions: StimulusType[] = olderKidInstructionPractice.filter(
-      (trial: StimulusType) => trial.trialType == 'instructions',
+      (trial: StimulusType) => trial.trialType === 'instructions',
     );
     const olderKidPractice: StimulusType[] = olderKidInstructionPractice.filter(
-      (trial: StimulusType) => trial.assessmentStage == 'practice_response',
+      (trial: StimulusType) => trial.assessmentStage === 'practice_response',
     );
 
     const olderKidBlocks: StimulusType[][] = prepareMultiBlockCat(taskStore().corpora.stimulus);
@@ -229,10 +229,10 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
     if (heavyInstructions) {
       const downexInstructionPractice: StimulusType[] = allCorpusParts.ipHeavy;
       const downexInstructions: StimulusType[] = downexInstructionPractice.filter(
-        (trial) => trial.trialType == 'instructions',
+        (trial) => trial.trialType === 'instructions',
       );
       let downexPractice: StimulusType[] = downexInstructionPractice.filter(
-        (trial) => trial.assessmentStage == 'practice_response',
+        (trial) => trial.assessmentStage === 'practice_response',
       );
 
       let downexBlock: StimulusType[] = allCorpusParts.downexCat;

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -281,7 +281,7 @@ export const slider = (
         const answer = stim.answer.toString();
         const choices = layoutConfigMap?.[stim.itemId].response.values;
 
-        const feedbackHandler = addPracticeButtonListeners(answer, isTouchScreen, choices);
+        addPracticeButtonListeners(answer, isTouchScreen, choices);
       }
     },
     on_finish: (data: any) => {

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -207,7 +207,7 @@ export const slider = (
           btn.textContent = responseChoices[i];
 
           // flag correct answer if running in cypress
-          if (window.Cypress && _toNumber(btn.textContent) == answer) {
+          if (window.Cypress && _toNumber(btn.textContent) === answer) {
             btn.setAttribute('aria-label', 'correct');
           }
 

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -278,11 +278,10 @@ export const slider = (
       }
 
       if (isPractice) {
-        let feedbackHandler;
         const answer = stim.answer.toString();
         const choices = layoutConfigMap?.[stim.itemId].response.values;
 
-        feedbackHandler = addPracticeButtonListeners(answer, isTouchScreen, choices);
+        const feedbackHandler = addPracticeButtonListeners(answer, isTouchScreen, choices);
       }
     },
     on_finish: (data: any) => {

--- a/task-launcher/src/tasks/memory-game/helpers/grid.ts
+++ b/task-launcher/src/tasks/memory-game/helpers/grid.ts
@@ -40,7 +40,7 @@ export function generateRandomSequence({ numOfBlocks, sequenceLength, previousSe
     // even across trial sequences
 
     // Check the last square in the previous sequence
-    if (i == 0 && previousSequence && previousSequence[previousSequence.length - 1] === randomNumber) {
+    if (i === 0 && previousSequence && previousSequence[previousSequence.length - 1] === randomNumber) {
       i--;
       continue;
     }

--- a/task-launcher/src/tasks/mental-rotation/catTimeline.ts
+++ b/task-launcher/src/tasks/mental-rotation/catTimeline.ts
@@ -37,7 +37,7 @@ export default function buildMentalRotationCatTimeline(config: Record<string, an
     timeline: [getAudioResponse(mediaAssets)],
   };
 
-  let corpus: StimulusType[] = taskStore().corpora.stimulus;
+  const corpus: StimulusType[] = taskStore().corpora.stimulus;
   const translations: Record<string, string> = taskStore().translations;
   const validationErrorMap: Record<string, string> = {};
 

--- a/task-launcher/src/tasks/mental-rotation/helpers/animate.ts
+++ b/task-launcher/src/tasks/mental-rotation/helpers/animate.ts
@@ -1,11 +1,11 @@
 import { displaceAnimation, triggerAnimation } from '../../shared/helpers';
 
 export function animate(animation: string, itemToAnimate: string) {
-  if (animation == 'pulse') {
+  if (animation === 'pulse') {
     const elementToAnimate = document.getElementById(itemToAnimate);
 
     return triggerAnimation(elementToAnimate, 'pulse 2s 0s');
-  } else if (animation == 'drag') {
+  } else if (animation === 'drag') {
     const elementToAnimate = document.getElementById('stim-image');
     const dragTargetElement = document.getElementById(itemToAnimate);
     const blackOutImage = itemToAnimate === 'target';

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -353,6 +353,6 @@ export const afcStimulusInference = ({
     button_html: () => getButtonHtml(layoutConfigMap),
     on_load: () => doOnLoad(layoutConfigMap),
     on_finish: (data: any) => doOnFinish(data, task, layoutConfigMap),
-    response_ends_trial: () => (taskStore().nextStimulus.assessmentStage === 'practice_response' ? false : true),
+    response_ends_trial: () => taskStore().nextStimulus.assessmentStage !== 'practice_response',
   };
 };

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -46,7 +46,7 @@ function cleanAttributes(attributes: string[]) {
   if (!attributes.some((item) => nonWhiteBackgrounds.includes(item))) {
     attributes.push('white');
   }
-  if (!attributes.some((item) => !isNaN(Number(item)))) {
+  if (!attributes.some((item) => !Number.isNaN(Number(item)))) {
     attributes.splice(3, 0, '1');
   }
 

--- a/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
@@ -181,7 +181,7 @@ export const somethingSameDemo2 = {
       };
 
       setTimeout(() => {
-        PageAudioHandler.playAudio(mediaAssets.audio['sdsPrompt3DemoHeavyPart2'], audioConfig);
+        PageAudioHandler.playAudio(mediaAssets.audio.sdsPrompt3DemoHeavyPart2, audioConfig);
       }, 2500);
     }
 
@@ -193,7 +193,7 @@ export const somethingSameDemo2 = {
       onEnded: animateBottomButtons,
     };
 
-    PageAudioHandler.playAudio(mediaAssets.audio['sdsPrompt3DemoHeavyPart1'], audioConfig);
+    PageAudioHandler.playAudio(mediaAssets.audio.sdsPrompt3DemoHeavyPart1, audioConfig);
   },
   on_finish: () => {
     PageAudioHandler.stopAndDisconnectNode();

--- a/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
@@ -395,7 +395,7 @@ export const heavyPractice = practiceData.map((data) => {
     prompt_above_buttons: true,
     post_trial_gap: 350,
     button_choices: () => {
-      if (data.trialType === 'instructions' || data.trialType == 'something-same-1') {
+      if (data.trialType === 'instructions' || data.trialType === 'something-same-1') {
         return ['OK'];
       } else {
         const randomize = data.answer ? 'yes' : 'no';

--- a/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
@@ -169,7 +169,7 @@ export const legacyStimulus = (trial?: StimulusType) => {
     prompt_above_buttons: true,
     button_choices: () => {
       const stim = trial || taskStore().nextStimulus;
-      if (stim.trialType === 'instructions' || stim.trialType == 'something-same-1') {
+      if (stim.trialType === 'instructions' || stim.trialType === 'something-same-1') {
         return ['OK'];
       } else {
         const randomize = !!stim.answer ? 'yes' : 'no';

--- a/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
@@ -94,7 +94,7 @@ export const legacyStimulus = (trial?: StimulusType) => {
     type: jsPsychHtmlMultiResponse,
     data: () => {
       const stim = trial || taskStore().nextStimulus;
-      let isPracticeTrial = stim.assessmentStage === 'practice_response';
+      const isPracticeTrial = stim.assessmentStage === 'practice_response';
       return {
         save_trial: stim.assessmentStage !== 'instructions',
         assessment_stage: stim.assessmentStage,
@@ -172,7 +172,7 @@ export const legacyStimulus = (trial?: StimulusType) => {
       if (stim.trialType === 'instructions' || stim.trialType === 'something-same-1') {
         return ['OK'];
       } else {
-        const randomize = !!stim.answer ? 'yes' : 'no';
+        const randomize = stim.answer ? 'yes' : 'no';
         // Randomize choices if there is an answer
         const { choices } = prepareChoices(stim.answer, stim.distractors, randomize);
         return generateImageChoices(choices);

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -60,7 +60,7 @@ function getTestDimensionsHtml(stim: StimulusType) {
 function getSomethingSameHtml(stim: StimulusType) {
   const t = taskStore().translations;
 
-  const leftImageSrc: string = stim.trialType == 'something-same-1' ? stim.image[0] : (stim.image as string);
+  const leftImageSrc: string = stim.trialType === 'something-same-1' ? stim.image[0] : (stim.image as string);
 
   const leftPromptHtml = stim.trialType === 'something-same-2' ? `<p>${t[camelize(stim.audioFile[0])]}</p>` : '';
   const rightPromptHtml =
@@ -70,7 +70,7 @@ function getSomethingSameHtml(stim: StimulusType) {
 
   const leftImageHtml = `
     <button class='image-medium no-pointer-events' style="${
-      stim.trialType == 'something-same-1' ? 'visibility: hidden;' : ''
+      stim.trialType === 'something-same-1' ? 'visibility: hidden;' : ''
     }">
       <img src=${mediaAssets.images[camelize(leftImageSrc)]} alt=${leftImageSrc} />
     </button>
@@ -80,7 +80,7 @@ function getSomethingSameHtml(stim: StimulusType) {
   const randomize = stim.answer ? 'yes' : 'no';
   const { choices } = prepareChoices(stim.answer as string, stim.distractors as string[], randomize);
   const images: string[] =
-    stim.trialType == 'something-same-1'
+    stim.trialType === 'something-same-1'
       ? (stim.image as string[]).map((image) => {
           return `<img src=${mediaAssets.images[camelize(image)]} alt=${image} />`;
         })

--- a/task-launcher/src/tasks/shared/helpers/getCorpus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getCorpus.ts
@@ -86,7 +86,7 @@ const transformCSV = (csvInput: ParsedRowType[], sequentialStimulus: boolean, ta
 
     const newRow: StimulusType = {
       source: row.source,
-      block_index: parseInt(row.block_index),
+      block_index: parseInt(row.block_index, 10),
       task: row.task,
       // for testing, will be removed
       prompt: row.prompt,
@@ -132,7 +132,7 @@ const transformCSV = (csvInput: ParsedRowType[], sequentialStimulus: boolean, ta
     }
 
     if (row.task === 'same-different-selection') {
-      newRow.requiredSelections = parseInt(row.required_selections);
+      newRow.requiredSelections = parseInt(row.required_selections, 10);
     }
 
     const currentTrialType = newRow.trialType;

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -49,7 +49,7 @@ function handlePracticeButtonPress(
   const incorrectPromptKey =
     taskStore().task === 'mental-rotation' &&
     taskStore().heavyInstructions &&
-    taskStore().nextStimulus?.trialType == '2D'
+    taskStore().nextStimulus?.trialType === '2D'
       ? 'mentalRotationFeedbackIncorrectDownex'
       : 'feedbackTryAgain';
 

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -59,7 +59,7 @@ export function prepareCorpus(
   const possibleStartItems: StimulusType[] = normedTrials.filter(
     (trial) =>
       !excludedTrialTypes.includes(trial.trialType) &&
-      ((taskStore().task == 'egma-math' && trial.block_index === 0) || taskStore().task !== 'egma-math') &&
+      ((taskStore().task === 'egma-math' && trial.block_index === 0) || taskStore().task !== 'egma-math') &&
       Number(trial.difficulty) <= maxTrialDifficulty,
   );
   const startItems: StimulusType[] = selectNItems(possibleStartItems, 5);
@@ -138,7 +138,7 @@ export function prepareMultiBlockCat(corpus: StimulusType[], sequentialBlocks = 
     const prevBlock = currBlock;
     currBlock = Number(trial.block_index);
 
-    if (currBlock != undefined) {
+    if (currBlock !== undefined) {
       if (currBlock !== prevBlock) {
         blockList.push([trial]);
       } else {

--- a/task-launcher/src/tasks/shared/helpers/prepareCat.ts
+++ b/task-launcher/src/tasks/shared/helpers/prepareCat.ts
@@ -13,7 +13,6 @@ export function prepareCorpus(
   // limit random starting items so that their difficulty is less than 0
   const maxTrialDifficulty = 0;
   const cat: boolean = taskStore().runCat;
-  let corpora;
 
   let heavyInstructionPracticeTrials: StimulusType[] = [];
   let downexTestTrials: StimulusType[] = [];
@@ -51,7 +50,7 @@ export function prepareCorpus(
 
   // separate out normed/unnormed trials
   const unnormedTrials: StimulusType[] = corpusParts.test.filter(
-    (trial) => trial.difficulty == null || isNaN(Number(trial.difficulty)),
+    (trial) => trial.difficulty == null || Number.isNaN(Number(trial.difficulty)),
   );
   const normedTrials: StimulusType[] = corpusParts.test.filter((trial) => !unnormedTrials.includes(trial));
 
@@ -70,12 +69,12 @@ export function prepareCorpus(
     : normedTrials;
 
   const downexUnnormedTrials: StimulusType[] = downexTestTrials.filter(
-    (trial) => trial.difficulty == null || isNaN(Number(trial.difficulty)),
+    (trial) => trial.difficulty == null || Number.isNaN(Number(trial.difficulty)),
   );
 
   const downexCatCorpus: StimulusType[] = downexTestTrials.filter((trial) => !downexUnnormedTrials.includes(trial));
 
-  corpora = {
+  const corpora = {
     ipHeavy: corpusParts.ipHeavy, // downex instruction/practice trials
     ipLight: corpusParts.ipLight, // older kid instruction/practice
     start: startItems, // 5 random items to be used in starting block (all under a certain max difficulty)

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -111,7 +111,7 @@ function getPrompt(layoutConfigMap: Record<string, LayoutConfigType>, trial?: St
       stimText: stimulusTextConfig,
     } = itemLayoutConfig;
     const mediaAsset = stimulusTextConfig?.value
-      ? mediaAssets.images[camelize(stimulusTextConfig.value)] || mediaAssets.images['blank']
+      ? mediaAssets.images[camelize(stimulusTextConfig.value)] || mediaAssets.images.blank
       : null;
     const prompt = promptEnabled ? t[camelize(stim.audioFile)] : null;
     const mediaSrc = showStimImage ? mediaAsset : null;

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -261,7 +261,7 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
 
   // should log trialsOfCurrentType - race condition
   if (stim.task === 'math') {
-    if (twoTrialsAgoStimulus != undefined && stim.trialType === twoTrialsAgoStimulus[0]?.trialType) {
+    if (twoTrialsAgoStimulus !== undefined && stim.trialType === twoTrialsAgoStimulus[0]?.trialType) {
       trialsOfCurrentType += 1;
     } else {
       trialsOfCurrentType = 0;

--- a/task-launcher/src/tasks/shared/trials/setup.ts
+++ b/task-launcher/src/tasks/shared/trials/setup.ts
@@ -19,7 +19,7 @@ const fixationTrial = (corpusType?: string, blockNum?: number) => {
     },
     on_finish: () => {
       if (corpusType) {
-        if (blockNum != undefined) {
+        if (blockNum !== undefined) {
           getStimulus(corpusType, blockNum);
         } else {
           getStimulus(corpusType);

--- a/task-launcher/webpack.config.cjs
+++ b/task-launcher/webpack.config.cjs
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const HtmlWebpackPlugin = require('html-webpack-plugin');


### PR DESCRIPTION
Related to #466.
- `noDoubleEquals`: `==` → `===`
- Warnings: parseInt radix, Number.isNaN, useConst, node: imports, a few style cleanups

Lint-only changes. Harder fixes will be a follow-up PR.