### PR TITLE
Chore: bump to 1.3.3

### DIFF
--- a/task-launcher/package-lock.json
+++ b/task-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@levante-framework/core-tasks",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@levante-framework/core-tasks",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "dependencies": {
         "@bdelab/jscat": "^3.0.3",

--- a/task-launcher/package.json
+++ b/task-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@levante-framework/core-tasks",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "main": "lib/index.1298d4fd.js",
   "module": "lib/index.1298d4fd.js",


### PR DESCRIPTION
The last publish was run from a branch, not `main`, and the auto version bump wasn't committed. This PR manually bumps this package to 1.3.3.