### PR TITLE
Chore: bump to 1.3.4

### DIFF
--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           token: ${{ steps.checkout_token.outputs.token }}
 
+      - name: Ensure on main
+        if: ${{ inputs.bump-and-tag }}
+        run: |
+          if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+            echo "Publish must be run from main" && exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -76,7 +76,11 @@ jobs:
       - name: Bump package version
         if: ${{ inputs.bump-and-tag }}
         run: |
-          npm version ${{ inputs.version-type }} --message "chore: release v%s [skip ci]"
+          npm version ${{ inputs.version-type }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          git add package.json package-lock.json
+          git commit -m "chore: release v$NEW_VERSION [skip ci]"
+          git tag -a "v$NEW_VERSION" -m "chore: release v$NEW_VERSION"
 
       - name: Resolve version
         id: resolve_version

--- a/.github/workflows/deploy-and-publish.yml
+++ b/.github/workflows/deploy-and-publish.yml
@@ -82,24 +82,25 @@ jobs:
 
       - name: Bump package version
         if: ${{ inputs.bump-and-tag }}
-        run: |
-          npm version ${{ inputs.version-type }} --no-git-tag-version
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          git add package.json package-lock.json
-          git commit -m "chore: release v$NEW_VERSION [skip ci]"
-          git tag -a "v$NEW_VERSION" -m "chore: release v$NEW_VERSION"
+        run: npm version ${{ inputs.version-type }} --no-git-tag-version
 
       - name: Resolve version
         id: resolve_version
         run: echo "new_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Push version commit and tag
-        if: ${{ inputs.bump-and-tag }}
-        run: git push --follow-tags
-
       - name: Publish to npm
         if: ${{ inputs.bump-and-tag }}
         run: npm publish --access public
+
+      - name: Commit and push version bump and tag
+        if: ${{ inputs.bump-and-tag }}
+        env:
+          NEW_VERSION: ${{ steps.resolve_version.outputs.new_version }}
+        run: |
+          git add package.json package-lock.json
+          git commit -m "chore: release v$NEW_VERSION [skip ci]"
+          git tag -a "v$NEW_VERSION" -m "chore: release v$NEW_VERSION"
+          git push --follow-tags
 
   update-dashboard:
     if: ${{ inputs.update-dashboard }}

--- a/task-launcher/package-lock.json
+++ b/task-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@levante-framework/core-tasks",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@levante-framework/core-tasks",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "dependencies": {
         "@bdelab/jscat": "^3.0.3",

--- a/task-launcher/package.json
+++ b/task-launcher/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@levante-framework/core-tasks",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
-  "main": "lib/index.1298d4fd.js",
-  "module": "lib/index.1298d4fd.js",
+  "main": "lib/index.11da1476.js",
+  "module": "lib/index.11da1476.js",
   "type": "module",
   "files": [
     "lib",


### PR DESCRIPTION
The previous run of `deploy-and-publish.yml` revealed an issue that I introduced in #467 - it published 1.3.4 to npm, but failed to push the bump commit/tag. This occurred because `npm version` does not create refs when run in a subdirectory.

This PR manually bumps `task-launcher/package.json`, `task-launcher/package-lock.json` to 1.3.4 and fixes the issue in `.github/workflows/deploy-and-publish.yml`.

Also adds an `Ensure on main` guard step, and reorders the release flow so npm publish happens before git commit/tag (in order that the `main`/`module` values in `package.json` no longer drift).