### PR TITLE
fix: resolve Biome low-risk warnings (#466)

### DIFF
--- a/task-launcher/cypress/support/e2e.js
+++ b/task-launcher/cypress/support/e2e.js
@@ -22,7 +22,7 @@ import './commands';
 import 'cypress-real-events';
 
 // prevent firestore error from failing test
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', (err, _runnable) => {
   if (err.message.includes('user not in Firestore')) {
     return false;
   }

--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/browser';
 import i18next from 'i18next';
-import firebaseJSON from '../firebase.json';
 import { TaskLauncher } from '../src';
 import { stringToBoolean } from '../src/tasks/shared/helpers/stringToBoolean';
 

--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -61,7 +61,6 @@ const heavyInstructions = stringToBoolean(urlParams.get('heavyInstructions'), fa
 const experimenterButtons = stringToBoolean(urlParams.get('experimenterButtons'), false);
 const debug = stringToBoolean(urlParams.get('debug'), false);
 
-const emulatorConfig = EMULATORS ? firebaseJSON.emulators : undefined;
 // if running in demo mode, no data will be saved to Firestore
 const demoMode = DEMO;
 

--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -74,7 +74,7 @@ export class TaskLauncher {
       taskVisualAssets = await getMediaAssets(taskVisualBucket, {}, language, taskName);
       sharedVisualAssets = await getMediaAssets(sharedVisualBucket, {}, language, 'shared');
     } catch (error) {
-      throw new Error('Error fetching media assets: ' + error);
+      throw new Error(`Error fetching media assets: ${error}`);
     }
 
     const config = await setConfig(this.firekit, this.gameParams, this.userParams);

--- a/task-launcher/src/tasks/child-survey/helpers/config.ts
+++ b/task-launcher/src/tasks/child-survey/helpers/config.ts
@@ -14,9 +14,9 @@ export const getLayoutConfig = (
   stimulus: StimulusType,
   translations: Record<string, string>,
   mediaAssets: MediaAssetsType,
-  trialNumber: number,
+  _trialNumber: number,
 ): GetConfigReturnType => {
-  const { answer, distractors, trialType } = stimulus;
+  const { distractors } = stimulus;
   const defaultConfig: LayoutConfigType = JSON.parse(JSON.stringify(DEFAULT_LAYOUT_CONFIG));
   const stimItem = convertItemToString(stimulus.item);
   defaultConfig.isPracticeTrial = stimulus.assessmentStage === 'practice_response';

--- a/task-launcher/src/tasks/child-survey/helpers/stimulus.ts
+++ b/task-launcher/src/tasks/child-survey/helpers/stimulus.ts
@@ -18,13 +18,12 @@ import { updateProgressBar } from '../../shared/helpers/updateProgressBar';
 import { jsPsych } from '../../taskSetup';
 
 const replayButtonHtmlId = 'replay-btn-revisited';
-let startTime: number;
 let selectedButtonIndex: number;
 
 export const surveyItem = ({
-  responseAllowed,
+  responseAllowed: _responseAllowed,
   promptAboveButtons,
-  task,
+  task: _task,
   layoutConfigMap,
 }: {
   responseAllowed: boolean;
@@ -76,8 +75,6 @@ export const surveyItem = ({
                 </button>`;
     },
     on_load: async () => {
-      startTime = performance.now();
-
       const stim = taskStore().nextStimulus;
       const itemLayoutConfig: LayoutConfigType = layoutConfigMap?.[stim.itemId];
       const playAudioOnLoad = itemLayoutConfig?.playAudioOnLoad;
@@ -182,14 +179,10 @@ export const surveyItem = ({
       // update the trial number
       taskStore.transact('trialNumSubtask', (oldVal: number) => oldVal + 1);
     },
-    on_finish: (data: any) => {
+    on_finish: (_data: any) => {
       disableStagger();
       PageAudioHandler.stopAndDisconnectNode();
 
-      let responseValue = null;
-      let responseIndex = null;
-
-      const t = taskStore().translations;
       const corpus = taskStore().corpus;
       const stim = taskStore().nextStimulus;
       const itemLayoutConfig: LayoutConfigType = layoutConfigMap?.[stim.itemId];
@@ -201,8 +194,6 @@ export const surveyItem = ({
           if (!response) {
             throw new Error('Choices not defined in the config');
           }
-          responseIndex = data.button_response;
-          responseValue = response.values[responseIndex];
         }
 
         jsPsych.data.addDataToLastTrial({

--- a/task-launcher/src/tasks/child-survey/helpers/stimulus.ts
+++ b/task-launcher/src/tasks/child-survey/helpers/stimulus.ts
@@ -179,7 +179,7 @@ export const surveyItem = ({
       // update the trial number
       taskStore.transact('trialNumSubtask', (oldVal: number) => oldVal + 1);
     },
-    on_finish: (_data: any) => {
+    on_finish: (_data: unknown) => {
       disableStagger();
       PageAudioHandler.stopAndDisconnectNode();
 

--- a/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/helpers/touchResponseRouting.js
@@ -58,7 +58,7 @@ function triggerToast() {
         toast.classList.remove('show');
       }
     }, 5000);
-  } else if (toast && toast.classList.contains('show')) {
+  } else if (toast?.classList.contains('show')) {
     clearTimeout(timeoutID);
 
     timeoutID = setTimeout(() => {

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -146,11 +146,10 @@ function getHeartOrFlowerSubtimelines(adminConfig, stimulusType) {
 }
 
 //TODO: check if we need to repeat the whole pair when user gets it wrong or if getting right on the feedback trial is enough
-function getHeartOrFlowerInstructionsSection(adminConfig, stimulusType) {
+function getHeartOrFlowerInstructionsSection(_adminConfig, stimulusType) {
   // To build our trials for the Instruction section, let's first gather all the static data
   let instructionPracticeStimulusSide1, instructionPracticePromptText1, instructionPracticePromptAudio1;
   let instructionPracticeStimulusSide2, instructionPracticePromptText2, instructionPracticePromptAudio2;
-  const audioAsset = mediaAssets.audio.heartInstruct1;
   if (stimulusType === StimulusType.Heart) {
     //First instruction practice
     instructionPracticeStimulusSide1 = StimulusSideType.Left;
@@ -240,7 +239,7 @@ function getHeartOrFlowerPracticeSection(adminConfig, stimulusType) {
   const onStimulusTrialFinishTimelineCallback = (data) => {
     practiceWinStreakCount = data.correct ? practiceWinStreakCount + 1 : 0;
   };
-  const onFeedbackTrialFinishTimelineCallback = (data) => {
+  const onFeedbackTrialFinishTimelineCallback = (_data) => {
     if (practiceWinStreakCount >= adminConfig.correctPracticeTrial) {
       // console.log(`practice block shortcut ready: win streak=${practiceWinStreakCount}`);
       jsPsych.endCurrentTimeline();
@@ -308,7 +307,7 @@ function getHeartOrFlowerTestSection(adminConfig, stimulusType) {
   return subtimeline;
 }
 
-function getMixedInstructionsSection(adminConfig) {
+function getMixedInstructionsSection(_adminConfig) {
   // feedback-good-job, "Good job!" //TODO: double-check ok to use feedback-good-job instead of "Great! That's right!" which is absent from item bank anyway
   const instructionPracticeFeedback = buildStimulusInvariantPracticeFeedback(
     'heartsAndFlowersTryAgain',
@@ -337,11 +336,11 @@ function getMixedInstructionsSection(adminConfig) {
   // Instruction practice trials do not advance until user gets it right
   subtimeline.push({
     timeline: [instructionPractice1, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().isCorrect === false,
+    loop_function: (_data) => taskStore().isCorrect === false,
   });
   subtimeline.push({
     timeline: [instructionPractice2, instructionPracticeFeedback],
-    loop_function: (data) => taskStore().isCorrect === false,
+    loop_function: (_data) => taskStore().isCorrect === false,
   });
 
   return subtimeline;
@@ -353,7 +352,7 @@ function getMixedPracticeSection(adminConfig) {
   const onStimulusTrialFinishTimelineCallback = (data) => {
     practiceWinStreakCount = data.correct ? practiceWinStreakCount + 1 : 0;
   };
-  const onFeedbackTrialFinishTimelineCallback = (data) => {
+  const onFeedbackTrialFinishTimelineCallback = (_data) => {
     if (practiceWinStreakCount >= adminConfig.correctPracticeTrial) {
       // console.info(`Ending practice block early: win streak=${practiceWinStreakCount}`);
       jsPsych.endCurrentTimeline();

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/instructions.js
@@ -79,8 +79,6 @@ function buildInstructionTrial(mascotImage, getPromptKey, showResponseButton = f
     console.error(`buildInstructionTrial: Missing prompt audio or text`);
   }
 
-  const replayButtonHtmlId = 'replay-btn-revisited';
-
   const trial = {
     type: jsPsychHtmlMultiResponse,
     stimulus: () => {

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/practice.js
@@ -173,7 +173,6 @@ function buildPracticeFeedback(
   flowerfeedbackPromptCorrectKey,
   onFinishTimelineCallback,
 ) {
-  const hfV2 = taskStore().version === 2;
   const validAnswerButtonHtmlIdentifier = 'valid-answer-btn';
   const feedbackTexts = {
     IncorrectHeart: taskStore().translations[heartFeedbackPromptIncorrectKey],

--- a/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/trials/stimulus.js
@@ -133,8 +133,7 @@ export function stimulus(isPractice, stage, trialType, stimulusDuration, onTrial
       taskStore('stimulusSide', stimuluSide);
 
       // save item uid for data analysis
-      const itemUid =
-        'hf_' + `${trialType === 'hearts and flowers' ? 'heartsflowers' : trialType}` + '_' + stimulusType;
+      const itemUid = `hf_${trialType === 'hearts and flowers' ? 'heartsflowers' : trialType}_${stimulusType}`;
 
       jsPsych.data.addDataToLastTrial({
         item: stimulusType,

--- a/task-launcher/src/tasks/math/helpers/config.ts
+++ b/task-launcher/src/tasks/math/helpers/config.ts
@@ -16,7 +16,7 @@ export const getLayoutConfig = (
   stimulus: StimulusType,
   translations: Record<string, string>,
   mediaAssets: MediaAssetsType,
-  trialNumber: number,
+  _trialNumber: number,
 ): GetConfigReturnType => {
   const { answer, distractors, trialType } = stimulus;
   const defaultConfig: LayoutConfigType = JSON.parse(JSON.stringify(DEFAULT_LAYOUT_CONFIG));

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -48,7 +48,7 @@ function setUpAudio(cue: string) {
 
 function captureValue(
   btnElement: HTMLButtonElement | null,
-  event: Event & { key?: string },
+  _event: Event & { key?: string },
   i: number,
   isPractice: boolean,
   choice?: string,
@@ -138,14 +138,13 @@ export const slider = (
       startTime = performance.now();
 
       const stim = (trial || taskStore().nextStimulus) as StimulusType;
-      const { distractors } = stim;
       const itemLayoutConfig = layoutConfigMap[stim.itemId];
       const incorrectPracticeResponses: Array<string | null> = [];
       taskStore('incorrectPracticeResponses', incorrectPracticeResponses);
 
       const slider = document.getElementById('jspsych-html-slider-response-response') as HTMLInputElement;
       const sliderLabels = document.getElementsByTagName('span') as HTMLCollectionOf<HTMLSpanElement>;
-      Array.from(sliderLabels).forEach((el, i) => {
+      Array.from(sliderLabels).forEach((el, _i) => {
         //if (i == 1 || i == 2) {
         el.style.fontSize = '1.5rem';
         //}

--- a/task-launcher/src/tasks/math/trials/sliderStimulus.ts
+++ b/task-launcher/src/tasks/math/trials/sliderStimulus.ts
@@ -99,7 +99,7 @@ export const slider = (
               ? `<div class="lev-row-container instruction">
                 <p>
                   ${t[camelize(stim.audioFile)]}
-                  ${isSlider ? '<br /> ' + stim.answer : ''}
+                  ${isSlider ? `<br /> ${stim.answer}` : ''}
                 </p> 
               </div>`
               : ''

--- a/task-launcher/src/tasks/matrix-reasoning/helpers/config.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/helpers/config.ts
@@ -15,7 +15,7 @@ export const getLayoutConfig = (
   stimulus: StimulusType,
   translations: Record<string, string>,
   mediaAssets: MediaAssetsType,
-  trialNumber: number,
+  _trialNumber: number,
 ): GetConfigReturnType => {
   const { answer, distractors, trialType } = stimulus;
   const defaultConfig: LayoutConfigType = JSON.parse(JSON.stringify(DEFAULT_LAYOUT_CONFIG));

--- a/task-launcher/src/tasks/matrix-reasoning/timeline.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/timeline.ts
@@ -143,23 +143,21 @@ export default function buildMatrixTimeline(config: Record<string, any>, mediaAs
       downexInstructions1,
       ...downexCorpus
         .slice(0, secondPhaseIndex)
-        .map((trial) => [
+        .flatMap((trial) => [
           { ...fixationOnly, stimulus: '' },
           downexStimulus(layoutConfigMap, true, trial),
           ifRealTrialResponse,
-        ])
-        .flat(),
+        ]),
       downexInstructions2,
       downexInstructions3,
       practiceTransition(undefined, true),
       ...downexCorpus
         .slice(secondPhaseIndex)
-        .map((trial) => [
+        .flatMap((trial) => [
           { ...fixationOnly, stimulus: '' },
           downexStimulus(layoutConfigMap, false, trial),
           ifRealTrialResponse,
-        ])
-        .flat(),
+        ]),
       downexInstructions4,
       downexInstructions5,
     ],

--- a/task-launcher/src/tasks/matrix-reasoning/trials/downexStimulus.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/downexStimulus.ts
@@ -16,7 +16,6 @@ import {
 import { isTouchScreen, jsPsych } from '../../taskSetup';
 
 const replayButtonHtmlId = 'replay-btn-revisited';
-let practiceResponses = [];
 let startTime: number;
 let cycleId = 0; // disable audio if the trial has changed since the loop started - prevent overlapping audio
 
@@ -185,7 +184,7 @@ export const downexStimulus = (
           const audioUri = mediaAssets.audio[camelize(trialAudio)] || mediaAssets.audio.nullAudio;
           PageAudioHandler.playAudio(audioUri);
         } else {
-          for (const [index, audioFile] of trialAudio.entries()) {
+          for (const [_index, audioFile] of trialAudio.entries()) {
             const audioUri = mediaAssets.audio[camelize(audioFile)] || mediaAssets.audio.nullAudio;
 
             // make sure the trial has not changed since the loop started
@@ -249,7 +248,6 @@ export const downexStimulus = (
           taskStore.transact('totalCorrect', (oldVal: number) => oldVal + 1);
           taskStore('numIncorrect', 0); // reset incorrect trial count
         }
-        practiceResponses = [];
       } else {
         // Only increase incorrect trials if response is incorrect not a practice trial
         if (stimulus.assessmentStage !== 'practice_response') {

--- a/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
@@ -19,8 +19,6 @@ import {
 import { pulseOkButton } from '../../shared/helpers/pulseOkButton';
 import { isTouchScreen, jsPsych } from '../../taskSetup';
 
-let startTime: number;
-
 export const instructionData = [
   {
     prompt: 'matrixReasoningInstruct1',
@@ -184,8 +182,6 @@ export const downexInstructions1 = {
   },
   keyboard_choices: () => 'NO_KEYS',
   on_load: async () => {
-    startTime = performance.now();
-
     addExperimenterButtons();
     setupFullscreenButton();
 
@@ -398,8 +394,6 @@ export const downexInstructions3 = {
   button_html: () => '<button class="image-matrix practice-btn"; disabled>%choice%</button>',
   keyboard_choices: () => 'NO_KEYS',
   on_load: async () => {
-    startTime = performance.now();
-
     addExperimenterButtons();
     setupFullscreenButton();
 
@@ -565,8 +559,6 @@ export const downexInstructions4 = {
   button_html: () => '<button class="image-matrix practice-btn" disabled>%choice%</button>',
   keyboard_choices: () => 'NO_KEYS',
   on_load: async () => {
-    startTime = performance.now();
-
     addExperimenterButtons();
     setupFullscreenButton();
 

--- a/task-launcher/src/tasks/memory-game/helpers/getMemoryGameType.ts
+++ b/task-launcher/src/tasks/memory-game/helpers/getMemoryGameType.ts
@@ -7,7 +7,7 @@ export const getMemoryGameType = (mode: 'input' | 'display', reverse: boolean, g
     memoryGameType = reverse ? 'backward-training' : 'forward-training';
   }
 
-  memoryGameType += '-' + gridSize;
+  memoryGameType += `-${gridSize}`;
 
   return memoryGameType;
 };

--- a/task-launcher/src/tasks/memory-game/trials/stimulus.ts
+++ b/task-launcher/src/tasks/memory-game/trials/stimulus.ts
@@ -193,7 +193,6 @@ export function getCorsiBlocks({
       }
 
       const gridSize = taskStore().gridSize;
-      const heavyInstructions = taskStore().heavyInstructions;
 
       // save itemUid for data analysis
       const itemUid =
@@ -240,8 +239,6 @@ export function getCorsiBlocks({
         }
 
         selectedCoordinates = [];
-
-        const numOfBlocks = taskStore().numOfBlocks;
 
         if (!isPractice) {
           timeoutIDs.forEach((id) => {

--- a/task-launcher/src/tasks/mental-rotation/catTimeline.ts
+++ b/task-launcher/src/tasks/mental-rotation/catTimeline.ts
@@ -180,7 +180,7 @@ export default function buildMentalRotationCatTimeline(config: Record<string, an
   };
 
   function addInstructionPractice() {
-    batchedCorpus.forEach((block, index) => {
+    batchedCorpus.forEach((_block, index) => {
       timeline.push(instructionPracticeBlock(index + 1));
     });
   }

--- a/task-launcher/src/tasks/mental-rotation/trials/instructions.ts
+++ b/task-launcher/src/tasks/mental-rotation/trials/instructions.ts
@@ -65,8 +65,6 @@ const data = [
   },
 ];
 
-let startTime: number;
-
 export const instructions = data.map((data: any) => {
   return {
     type: jsPsychHtmlMultiResponse,
@@ -107,8 +105,6 @@ export const instructions = data.map((data: any) => {
     },
     keyboard_choices: () => 'NO_KEYS',
     on_load: async () => {
-      startTime = performance.now();
-
       addExperimenterButtons();
       setupFullscreenButton();
 

--- a/task-launcher/src/tasks/roar-inference/helpers/config.ts
+++ b/task-launcher/src/tasks/roar-inference/helpers/config.ts
@@ -15,7 +15,7 @@ export const getLayoutConfig = (
   stimulus: StimulusType,
   translations: Record<string, string>,
   mediaAssets: MediaAssetsType,
-  trialNumber: number,
+  _trialNumber: number,
 ): GetConfigReturnType => {
   const { answer, distractors, trialType } = stimulus;
   const defaultConfig: LayoutConfigTypeInference = JSON.parse(JSON.stringify(DEFAULT_LAYOUT_CONFIG));

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -288,7 +288,7 @@ function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, Lay
     if (taskStore().storeItemId) {
       jsPsych.data.addDataToLastTrial({
         corpus: taskStore().corpus,
-        itemId: stimulus.source + '-' + stimulus.origItemNum,
+        itemId: `${stimulus.source}-${stimulus.origItemNum}`,
       });
     }
 

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -1,16 +1,8 @@
 import jsPsychHtmlMultiResponse from '@jspsych-contrib/plugin-html-multi-response';
 import _toNumber from 'lodash/toNumber';
 import { taskStore } from '../../../taskStore';
-import {
-  arrowKeyEmojis,
-  PageStateHandler,
-  setSentryContext,
-  setSkipCurrentBlock,
-  //@ts-ignore
-} from '../../shared/helpers';
-// @ts-ignore
+import { arrowKeyEmojis, PageStateHandler, setSentryContext, setSkipCurrentBlock } from '../../shared/helpers';
 import { finishExperiment } from '../../shared/trials';
-// @ts-ignore
 import { isTouchScreen, jsPsych } from '../../taskSetup';
 import type { LayoutConfigTypeInference } from '../types/inferenceTypes';
 

--- a/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/afcInference.ts
@@ -16,7 +16,6 @@ import type { LayoutConfigTypeInference } from '../types/inferenceTypes';
 
 // Previously chosen responses for current practice trial
 let practiceResponses = [];
-let trialsOfCurrentType = 0;
 let keyboardFeedbackHandler: (ev: KeyboardEvent) => void;
 const incorrectPracticeResponses: Array<string | null> = [];
 
@@ -68,7 +67,6 @@ const getPromptTemplate = (prompt: string, story?: string | null, useStimText?: 
 function getPrompt(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   // showItem itemIsImage
   const stim = taskStore().nextStimulus;
-  const t = taskStore().translations;
 
   const itemLayoutConfig = layoutConfigMap?.[stim.itemId];
 
@@ -169,7 +167,6 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   const playAudioOnLoad = itemLayoutConfig?.playAudioOnLoad;
   const pageStateHandler = new PageStateHandler(stim.audioFile, playAudioOnLoad); // this falls to nullAudio
   const isPracticeTrial = stim.assessmentStage === 'practice_response';
-  const isInstructionTrial = stim.trialType === 'instructions';
   // Handle the staggered buttons
   handleStaggeredButtons(itemLayoutConfig, pageStateHandler);
   // Setup Sentry Context
@@ -183,7 +180,7 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
     const practiceBtns: NodeListOf<HTMLButtonElement> = document.querySelectorAll('.practice-btn');
 
     practiceBtns.forEach((btn, i) => {
-      btn.addEventListener('click', async (e) => {
+      btn.addEventListener('click', async (_e) => {
         handlePracticeButtonPress(btn, stim, practiceBtns, false, i);
       });
     });
@@ -192,10 +189,6 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
       //   keyboardFeedbackHandler = (e: KeyboardEvent) => keyboardBtnFeedback(e, practiceBtns, stim, itemLayoutConfig);
       document.addEventListener('keydown', keyboardFeedbackHandler);
     }
-  }
-
-  if (!isPracticeTrial && !isInstructionTrial) {
-    trialsOfCurrentType += 1;
   }
 
   if (itemLayoutConfig?.classOverrides.stimulusContainerClassList.includes('inference-scroll')) {
@@ -233,7 +226,7 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   }
 }
 
-function doOnFinish(data: any, task: string, layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
+function doOnFinish(data: any, _task: string, layoutConfigMap: Record<string, LayoutConfigTypeInference>) {
   // note: nextStimulus is actually the current stimulus
   const stimulus = taskStore().nextStimulus;
   const itemLayoutConfig = layoutConfigMap?.[stimulus.itemId];

--- a/task-launcher/src/tasks/roar-inference/trials/instructions.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/instructions.ts
@@ -1,9 +1,7 @@
 import jsPsychAudioMultiResponse from '@jspsych-contrib/plugin-audio-multi-response';
 import { mediaAssets } from '../../..';
 import { taskStore } from '../../../taskStore';
-// @ts-ignore
 import { PageAudioHandler, PageStateHandler, replayButtonSvg, setupReplayAudio } from '../../shared/helpers';
-// @ts-ignore
 import { jsPsych } from '../../taskSetup';
 
 const instructionData = [

--- a/task-launcher/src/tasks/roar-inference/trials/instructions.ts
+++ b/task-launcher/src/tasks/roar-inference/trials/instructions.ts
@@ -40,7 +40,6 @@ export const instructions = instructionData.map((data) => {
     prompt_above_buttons: true,
     button_choices: ['Next'],
     button_html: () => {
-      const t = taskStore().translations;
       return [
         `<button class="primary">
             ${[data.buttonText]}

--- a/task-launcher/src/tasks/same-different-selection/catTimeline.ts
+++ b/task-launcher/src/tasks/same-different-selection/catTimeline.ts
@@ -111,7 +111,7 @@ export default function buildSameDifferentTimelineCat(config: Record<string, any
             (stimulus.trialType.includes('something-same') && trialNum === 2)
           );
         } else {
-          return stimulus.trialType === trialNum + '-match';
+          return stimulus.trialType === `${trialNum}-match`;
         }
       },
     };

--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -71,7 +71,7 @@ function compareSelections(selections: string[], previousSelections: string[][],
   function sharedTrait(selections: string[], ignoreDims: string[]) {
     const sets: Record<string, Set<string>> = {};
     // Initialize sets for each non-ignored dimension
-    for (const [dim, index] of Object.entries(dimensionIndices)) {
+    for (const [dim, _index] of Object.entries(dimensionIndices)) {
       if (!ignoreDims.includes(dim)) {
         sets[dim] = new Set();
       }
@@ -308,7 +308,7 @@ export const afcMatch = (trial?: StimulusType) => {
           buttonContainer.classList.add('lev-response-row', 'multi-4');
         }
         responseBtns.forEach((card, i) => {
-          card.addEventListener('click', async (e) => {
+          card.addEventListener('click', async (_e) => {
             const answer = ((card as HTMLButtonElement)?.firstChild as HTMLImageElement)?.alt;
 
             if (!card) {

--- a/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/heavyInstructions.ts
@@ -455,7 +455,7 @@ export const heavyPractice = practiceData.map((data) => {
           .filter((btn) => !!btn) as HTMLButtonElement[];
 
         practiceBtns.forEach((card, i) => {
-          card.addEventListener('click', async (e) => {
+          card.addEventListener('click', async (_e) => {
             handleButtonFeedback(card, practiceBtns, false, i, data.correctAudio);
           });
         });

--- a/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/legacyStimulus.ts
@@ -269,7 +269,7 @@ export const legacyStimulus = (trial?: StimulusType) => {
         practiceBtns.forEach((card, i) => {
           const eventType = isTouchScreen ? 'touchend' : 'click';
 
-          card.addEventListener(eventType, (e) => {
+          card.addEventListener(eventType, (_e) => {
             handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob');
           });
         });

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -424,7 +424,7 @@ export const stimulus = (trial?: StimulusType) => {
         practiceBtns.forEach((card, i) => {
           const eventType = isTouchScreen ? 'touchend' : 'click';
 
-          card.addEventListener(eventType, (e) => {
+          card.addEventListener(eventType, (_e) => {
             handleButtonFeedback(card, practiceBtns, false, i, 'feedbackGoodJob');
           });
         });
@@ -432,12 +432,11 @@ export const stimulus = (trial?: StimulusType) => {
 
       displayDebugInfo(stimulus);
     },
-    on_finish: (data: any) => {
+    on_finish: (_data: any) => {
       PageAudioHandler.stopAndDisconnectNode();
       currentTrialId = '';
 
       const stim = trial || taskStore().nextStimulus;
-      const choices = taskStore().choices;
       const endTime = performance.now();
       const cat = taskStore().runCat;
 

--- a/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/stimulus.ts
@@ -432,7 +432,7 @@ export const stimulus = (trial?: StimulusType) => {
 
       displayDebugInfo(stimulus);
     },
-    on_finish: (_data: any) => {
+    on_finish: (_data: unknown) => {
       PageAudioHandler.stopAndDisconnectNode();
       currentTrialId = '';
 

--- a/task-launcher/src/tasks/shared/helpers/addUtilityButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/addUtilityButtons.ts
@@ -65,8 +65,8 @@ export function addExperimenterButtons() {
   // equalize button widths
   const popupButtons = popupButtonContainer.querySelectorAll('button');
   const standardWidth = popupButtons[0].getBoundingClientRect().width;
-  popupButtons[0].style.width = standardWidth.toString() + 'px';
-  popupButtons[1].style.width = standardWidth.toString() + 'px';
+  popupButtons[0].style.width = `${standardWidth}px`;
+  popupButtons[1].style.width = `${standardWidth}px`;
 
   document.body.appendChild(popup);
 }

--- a/task-launcher/src/tasks/shared/helpers/addUtilityButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/addUtilityButtons.ts
@@ -136,7 +136,9 @@ function onResume() {
 function onExit() {
   openPopup();
 
-  const popupButtons = document.getElementById('exit-confirmation-popup-buttons')!.querySelectorAll('button');
+  const popupContainer = document.getElementById('exit-confirmation-popup-buttons');
+  if (!popupContainer) return;
+  const popupButtons = popupContainer.querySelectorAll('button');
   popupButtons[0].addEventListener('click', () => {
     document.body.innerHTML = '';
     taskStore('taskComplete', true);
@@ -149,11 +151,12 @@ function onExit() {
     const exitButton = document.getElementById('exit');
     const pauseButton = document.getElementById('pause');
 
-    exitButton!.style.display = 'none';
-    pauseButton!.style.display = 'none';
-
-    menuButton!.classList.remove('open');
-    menuButton!.setAttribute('state', 'closed');
+    if (exitButton) exitButton.style.display = 'none';
+    if (pauseButton) pauseButton.style.display = 'none';
+    if (menuButton) {
+      menuButton.classList.remove('open');
+      menuButton.setAttribute('state', 'closed');
+    }
   });
 }
 
@@ -172,16 +175,14 @@ function onMenuPress(menuButton: HTMLButtonElement) {
   const pauseButton = document.getElementById('pause');
 
   if (menuButton.getAttribute('state') === 'closed') {
-    exitButton!.style.display = 'block';
-    pauseButton!.style.display = 'block';
-
-    menuButton!.classList.add('open');
+    if (exitButton) exitButton.style.display = 'block';
+    if (pauseButton) pauseButton.style.display = 'block';
+    menuButton.classList.add('open');
     menuButton.setAttribute('state', 'open');
   } else {
-    exitButton!.style.display = 'none';
-    pauseButton!.style.display = 'none';
-
-    menuButton!.classList.remove('open');
+    if (exitButton) exitButton.style.display = 'none';
+    if (pauseButton) pauseButton.style.display = 'none';
+    menuButton.classList.remove('open');
     menuButton.setAttribute('state', 'closed');
   }
 }

--- a/task-launcher/src/tasks/shared/helpers/animateImages.ts
+++ b/task-launcher/src/tasks/shared/helpers/animateImages.ts
@@ -41,7 +41,7 @@ export function displaceAnimation(
     const cursorImg = document.createElement('img');
     cursorImg.src = mediaAssets.images.pointingHand;
     cursorImg.style.position = 'absolute';
-    cursorImg.style.width = rect.width * 0.7 + 'px';
+    cursorImg.style.width = `${rect.width * 0.7}px`;
     cursorImg.style.height = 'auto';
     cursorImg.style.left = `${rect.left + rect.width / 4}px`;
     cursorImg.style.top = `${rect.top + rect.height / 4}px`;

--- a/task-launcher/src/tasks/shared/helpers/animateImages.ts
+++ b/task-launcher/src/tasks/shared/helpers/animateImages.ts
@@ -13,7 +13,7 @@ export function popAnimation(itemsToAnimate: any, animation: string) {
 }
 
 export function triggerAnimation(item: any, animation: string) {
-  if (item instanceof Array) {
+  if (Array.isArray(item)) {
     item.forEach((item) => {
       item.style.animation = 'none';
       item.offsetHeight; // Force reflow

--- a/task-launcher/src/tasks/shared/helpers/config.ts
+++ b/task-launcher/src/tasks/shared/helpers/config.ts
@@ -98,7 +98,7 @@ export const setSharedConfig = async (
     debug,
     version,
     taskVersion, // deprecated; use `version` — kept for backward compatibility
-    isPaused,
+    _isPaused,
   } = cleanParams;
 
   const config = {

--- a/task-launcher/src/tasks/shared/helpers/createPreloadTrials.ts
+++ b/task-launcher/src/tasks/shared/helpers/createPreloadTrials.ts
@@ -36,7 +36,7 @@ export function createPreloadTrials(categorizedObjects: MediaAssetsType, blocks:
 
   // Distribute URLs into the appropriate blocks
   Object.entries(categorizedObjects).forEach(([category, files]) => {
-    Object.entries(files).forEach(([fileName, url]) => {
+    Object.entries(files).forEach(([_fileName, url]) => {
       let fileAdded = false;
 
       for (const block of blocks) {

--- a/task-launcher/src/tasks/shared/helpers/dashToCamelCase.ts
+++ b/task-launcher/src/tasks/shared/helpers/dashToCamelCase.ts
@@ -1,3 +1,3 @@
 export function dashToCamelCase(str: string) {
-  return str.replace(/-([a-z])/gi, (match, letter) => letter.toUpperCase());
+  return str.replace(/-([a-z])/gi, (_match, letter) => letter.toUpperCase());
 }

--- a/task-launcher/src/tasks/shared/helpers/equalizeButtonSizes.ts
+++ b/task-launcher/src/tasks/shared/helpers/equalizeButtonSizes.ts
@@ -11,7 +11,7 @@ export function equalizeButtonSizes(buttons: NodeListOf<HTMLButtonElement>) {
 
   // resize all buttons to smallest width
   for (let i = 0; i < buttons.length; i++) {
-    buttons[i].style.width = Math.min(...buttonWidths).toString() + 'px';
+    buttons[i].style.width = `${Math.min(...buttonWidths)}px`;
   }
 
   // get new button heights (after automatically adjusted to accomdate different text)
@@ -22,7 +22,7 @@ export function equalizeButtonSizes(buttons: NodeListOf<HTMLButtonElement>) {
 
   // resize all buttons to max height and align with top of container
   for (let i = 0; i < buttons.length; i++) {
-    buttons[i].style.height = Math.max(...buttonHeights).toString() + 'px';
+    buttons[i].style.height = `${Math.max(...buttonHeights)}px`;
 
     const parentElement = buttons[i].parentElement;
     if (parentElement) {

--- a/task-launcher/src/tasks/shared/helpers/getCorpus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getCorpus.ts
@@ -69,7 +69,6 @@ function containsLettersOrSlash(str: string) {
 
 const transformCSV = (csvInput: ParsedRowType[], sequentialStimulus: boolean, task: string) => {
   let currTrialTypeBlock = '';
-  let currPracticeAmount = 0;
 
   const blockThresholds: number[] = [];
 
@@ -135,7 +134,6 @@ const transformCSV = (csvInput: ParsedRowType[], sequentialStimulus: boolean, ta
     const currentTrialType = newRow.trialType;
     if (currentTrialType !== currTrialTypeBlock) {
       currTrialTypeBlock = currentTrialType;
-      currPracticeAmount = 0;
     }
 
     if (newRow.downex) {
@@ -195,7 +193,7 @@ export const getCorpus = async (config: Record<string, any>, isDev: boolean) => 
   }
 
   async function parseCSVs(urls: string[]) {
-    const promises = urls.map((url, i) => downloadCSV(url));
+    const promises = urls.map((url, _i) => downloadCSV(url));
     return Promise.all(promises);
   }
 

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -10,7 +10,7 @@ import { camelize } from './camelize';
 
 export const getStimulus = (corpusType: string, blockNumber?: number, storyGroup?: number, randomize = false) => {
   let itemSuggestion: any;
-  let corpus = taskStore().corpora;
+  const corpus = taskStore().corpora;
 
   if (blockNumber != null) {
     // if block number is specified, get next item from only the indicated block of the corpus

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -21,7 +21,7 @@ export function addPracticeButtonListeners(
   practiceBtns.forEach((btn, i) => {
     const eventType = isTouchScreen ? 'touchend' : 'click';
 
-    btn.addEventListener(eventType, (e) => {
+    btn.addEventListener(eventType, (_e) => {
       handlePracticeButtonPress(btn, answer, practiceBtns, i, choices, onCorrect, onIncorrect);
     });
   });

--- a/task-launcher/src/tasks/shared/helpers/isTaskFinished.ts
+++ b/task-launcher/src/tasks/shared/helpers/isTaskFinished.ts
@@ -1,13 +1,14 @@
 // Previously named waitFor
 
-export const isTaskFinished = (conditionFunction: Function) => {
-  const poll = (resolve: Function) => {
-    if (conditionFunction()) {
-      resolve();
-    } else {
-      setTimeout(() => poll(resolve), 400);
-    }
-  };
-
-  return new Promise(poll);
+export const isTaskFinished = (conditionFunction: () => boolean) => {
+  return new Promise<void>((resolve) => {
+    const poll = () => {
+      if (conditionFunction()) {
+        resolve();
+      } else {
+        setTimeout(poll, 400);
+      }
+    };
+    poll();
+  });
 };

--- a/task-launcher/src/tasks/shared/helpers/staggerButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/staggerButtons.ts
@@ -14,7 +14,6 @@ export const handleStaggeredButtons = async (
   disableButtons = true,
 ) => {
   const parentResponseDiv = buttonContainer;
-  const i = 0;
   const stimulusDuration = await pageState.getStimulusDurationMs();
   const intialDelay = stimulusDuration + 300;
 

--- a/task-launcher/src/tasks/shared/trials/afcStimulus.ts
+++ b/task-launcher/src/tasks/shared/trials/afcStimulus.ts
@@ -27,9 +27,7 @@ import { finishExperiment } from '.';
 const replayButtonHtmlId = 'replay-btn-revisited';
 // Previously chosen responses for current practice trial
 let practiceResponses = [];
-let trialsOfCurrentType = 0;
 let startTime: number;
-const incorrectPracticeResponses: Array<string | null> = [];
 
 function getStimulus(layoutConfigMap: Record<string, LayoutConfigType>, trial?: StimulusType) {
   const stim = trial || taskStore().nextStimulus;
@@ -231,9 +229,6 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
     handleStaggeredButtons(pageStateHandler, buttonContainer, audioKeys);
   }
 
-  const currentTrialIndex = jsPsych.getProgress().current_trial_global;
-  let twoTrialsAgoIndex = currentTrialIndex - 2;
-
   // Setup Sentry Context
   setSentryContext({
     itemId: stim.itemId,
@@ -242,34 +237,18 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
   });
 
   if (stim.task === 'math') {
-    twoTrialsAgoIndex = currentTrialIndex - 3; // math has a fixation or something
-
     // flag correct answers with alt text for math if running a Cypress test
     if (window.Cypress && !isInstructionTrial) {
       const choices: NodeListOf<HTMLButtonElement> = document.querySelectorAll('.secondary, .image-medium, .primary');
       choices[itemLayoutConfig.response.targetIndex].setAttribute('aria-label', 'correct');
     }
   }
-  const twoTrialsAgoStimulus = jsPsych.data.get().filter({ trial_index: twoTrialsAgoIndex }).values();
 
   if (isPracticeTrial) {
     const answer = stim.answer.toString();
     const choices = layoutConfigMap?.[stim.itemId].response.values;
 
     addPracticeButtonListeners(answer, isTouchScreen, choices);
-  }
-
-  // should log trialsOfCurrentType - race condition
-  if (stim.task === 'math') {
-    if (twoTrialsAgoStimulus !== undefined && stim.trialType === twoTrialsAgoStimulus[0]?.trialType) {
-      trialsOfCurrentType += 1;
-    } else {
-      trialsOfCurrentType = 0;
-    }
-  } else {
-    if (!isPracticeTrial && !isInstructionTrial) {
-      trialsOfCurrentType += 1;
-    }
   }
 
   if (stim.trialType !== 'instructions') {
@@ -302,7 +281,7 @@ function doOnLoad(layoutConfigMap: Record<string, LayoutConfigType>, trial?: Sti
 
 function doOnFinish(
   data: any,
-  task: string,
+  _task: string,
   layoutConfigMap: Record<string, LayoutConfigType>,
   terminateCat: boolean,
   trial?: StimulusType,

--- a/task-launcher/src/tasks/shared/trials/dataQuality.ts
+++ b/task-launcher/src/tasks/shared/trials/dataQuality.ts
@@ -3,7 +3,6 @@ import { taskStore } from '../../../taskStore';
 import { jsPsych } from '../../taskSetup';
 import { finishExperiment } from './finishExperiment';
 
-const t = taskStore().translations;
 const buttonText = ['dataQuestionnaireButtonText1', 'dataQuestionnaireButtonText2', 'dataQuestionnaireButtonText3'];
 
 export const dataQualityScreen = {

--- a/task-launcher/src/tasks/shared/trials/fullScreen.ts
+++ b/task-launcher/src/tasks/shared/trials/fullScreen.ts
@@ -26,14 +26,20 @@ export const enterFullscreen = {
     }
 
     if (isTouchScreen) {
-      continueButton?.addEventListener('click', () => {
-        PageAudioHandler.unlockAudioContext();
-      }),
-        { once: true };
-      continueButton?.addEventListener('touchend', () => {
-        PageAudioHandler.unlockAudioContext();
-      }),
-        { once: true };
+      continueButton?.addEventListener(
+        'click',
+        () => {
+          PageAudioHandler.unlockAudioContext();
+        },
+        { once: true },
+      );
+      continueButton?.addEventListener(
+        'touchend',
+        () => {
+          PageAudioHandler.unlockAudioContext();
+        },
+        { once: true },
+      );
     }
 
     const inputDetector = setupInputDetection();

--- a/task-launcher/src/tasks/taskSetup.ts
+++ b/task-launcher/src/tasks/taskSetup.ts
@@ -10,7 +10,7 @@ export const isTouchScreen = getDevice() === 'mobile';
 
 export let cat: any;
 
-const { runCat } = taskStore();
+const { _runCat } = taskStore();
 
 export const initializeCat = () => {
   cat = new Cat({

--- a/task-launcher/src/tasks/taskSetup.ts
+++ b/task-launcher/src/tasks/taskSetup.ts
@@ -1,5 +1,5 @@
 import { Cat } from '@bdelab/jscat';
-//@ts-ignore
+//@ts-expect-error
 import { getDevice } from '@bdelab/roar-utils';
 import { initJsPsych } from 'jspsych';
 import '../i18n/i18n';

--- a/task-launcher/src/tasks/taskSetup.ts
+++ b/task-launcher/src/tasks/taskSetup.ts
@@ -10,8 +10,6 @@ export const isTouchScreen = getDevice() === 'mobile';
 
 export let cat: any;
 
-const { _runCat } = taskStore();
-
 export const initializeCat = () => {
   cat = new Cat({
     method: 'MLE',

--- a/task-launcher/src/tasks/trog/timeline.ts
+++ b/task-launcher/src/tasks/trog/timeline.ts
@@ -25,8 +25,6 @@ import { cat, initializeCat, jsPsych } from '../taskSetup';
 import { getLayoutConfig } from './helpers/config';
 
 export default function buildTROGTimeline(config: Record<string, any>, mediaAssets: MediaAssetsType) {
-  const preloadTrials = createPreloadTrials(mediaAssets).default;
-
   initTrialSaving(config);
   const initialTimeline = initTimeline(config, enterFullscreen);
   const corpus: StimulusType[] = taskStore().corpora.stimulus;


### PR DESCRIPTION
Fixes low-risk Biome warnings in task-launcher (#466).
Rebased onto main after #480
## Covers

- `noUnusedVariables` / `noUnusedFunctionParameters`
- `useTemplate` / `noUnusedImports`
- Style rules (`useFlatMap`, `useConst`, `useOptionalChain`, etc.)
- `noNonNullAssertion` (`addUtilityButtons`)
- `noBannedTypes` (`isTaskFinished`)
- `fullScreen` addEventListener fix
- Stale `@ts-ignore` removal (where safe)

## Results

- **Errors:** 0 (same as #480)
- **Warnings:** 69 (down from 152 on main)

## Remaining warnings — needs discussion

69 warnings left. Paused here — team input needed before touching:

- **`noExplicitAny` (64)** — needs proper jsPsych/trial types, not quick `unknown` swaps
- **`noBannedTypes` (3)** — includes `Function` types; mostly shared helpers / type defs
- **`noArguments` (2)** — `trialSaving.ts` Firestore hooks; wrong changes could break data saving

Happy to discuss next steps!