### PR TITLE
Matrix reasoning bug fixes 

### DIFF
--- a/task-launcher/src/tasks/matrix-reasoning/timeline.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/timeline.ts
@@ -247,7 +247,7 @@ export default function buildMatrixTimeline(config: Record<string, any>, mediaAs
       if (i % batchSize === 0) {
         preloadBatch();
       }
-      if (i <= fallbackIndex) {
+      if (i <= fallbackIndex && !heavyInstructions) {
         timeline.push(fallbackBlock);
       }
       timeline.push(stimulusBlock);

--- a/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
@@ -665,6 +665,9 @@ export const downexInstructions4 = {
     }
 
     animateAndPlayAudio();
+
+    // reset incorrect counter so that task doesn't end prematurely in later trials
+    taskStore('numIncorrect', 0);
   },
   response_ends_trial: false,
   on_finish: () => {


### PR DESCRIPTION
This PR addresses Freshdesk ticket 89, fixing two related bugs in matrix reasoning:

- The "fall back" feature (which gives the younger kid instructions and items after a certain number of incorrect trials) was being triggered immediately after the beginning of the older kid block if the user got trials wrong earlier in the task. This will no longer happen for younger kids
- Incorrect answers in the younger kid block were causing the task to error out later as soon as the older kid block started