### PR TITLE
Minor improvements to buttons on touch screens

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -31,10 +31,12 @@ button {
       border-radius: $button-default-border-radius-small;
     }
 
-    &:hover {
-      background: $bg-button-primary-hover;
-      border-color: $border-button-primary-hover;
-      box-shadow: $button-default-box-shadow rgba($border-button-primary-hover, 0.5) inset;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: $bg-button-primary-hover;
+        border-color: $border-button-primary-hover;
+        box-shadow: $button-default-box-shadow rgba($border-button-primary-hover, 0.5) inset;
+      }
     }
 
     &:active {
@@ -92,10 +94,12 @@ button {
       height: 3 * $font-size-m;
     }
 
-    &:hover {
-      background: $bg-button-primary-hover;
-      border-color: $border-button-primary-hover;
-      box-shadow: $bg-button-secondary inset;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: $bg-button-primary-hover;
+        border-color: $border-button-primary-hover;
+        box-shadow: $bg-button-secondary inset;
+      }
     }
 
     &:active {
@@ -137,12 +141,14 @@ button {
       min-height: 40px;
     }
 
-    &:hover {
-      background: $bg-green-base-hover;
-      border-color: $border-button-green-hover;
-      box-shadow:
-        $button-secondary-box-shadow $border-button-green-hover inset,
-        $button-secondary-inner-shadow $bg-green-gradient inset;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: $bg-green-base-hover;
+        border-color: $border-button-green-hover;
+        box-shadow:
+          $button-secondary-box-shadow $border-button-green-hover inset,
+          $button-secondary-inner-shadow $bg-green-gradient inset;
+      }
     }
 
     &:active {
@@ -170,10 +176,12 @@ button {
       border-radius: $button-default-border-radius-small;
     }
 
-    &:hover {
-      background: $bg-button-primary-hover;
-      border-color: $border-button-primary-hover;
-      box-shadow: $bg-button-secondary inset;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: $bg-button-primary-hover;
+        border-color: $border-button-primary-hover;
+        box-shadow: $bg-button-secondary inset;
+      }
     }
 
     &:active {
@@ -239,9 +247,11 @@ button {
       padding: 9px;
     }
 
-    &:hover {
-      background-color: rgba($bg-button-primary-hover, 0.4);
-      border: 2px solid $border-button-primary-hover;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: rgba($bg-button-primary-hover, 0.4);
+        border: 2px solid $border-button-primary-hover;
+      }
     }
 
     &:active {
@@ -310,8 +320,10 @@ button {
       }
     }
 
-    &:hover {
-      border-color: $bg-accent_secondary;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        border-color: $bg-accent_secondary;
+      }
     }
 
     &:active {
@@ -354,8 +366,10 @@ button {
       }
     }
 
-    &:hover {
-      border-color: $bg-accent_secondary;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        border-color: $bg-accent_secondary;
+      }
     }
 
     &:active {
@@ -390,8 +404,10 @@ button {
       float: left;
     }
 
-    &:hover {
-      border-color: $bg-accent_secondary;
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        border-color: $bg-accent_secondary;
+      }
     }
 
     &:active {

--- a/task-launcher/src/tasks/matrix-reasoning/trials/downexStimulus.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/downexStimulus.ts
@@ -122,13 +122,19 @@ export const downexStimulus = (
       const incorrectPracticeResponses: Array<string | null> = [];
       taskStore('incorrectPracticeResponses', incorrectPracticeResponses);
 
-      function onCorrect() {
+      function onCorrect(onFeedbackEnded: () => void) {
         PageAudioHandler.stopAndDisconnectNode();
         cycleId++;
-        PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne);
+        PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne, {
+          restrictRepetition: {
+            enabled: false,
+            maxRepetitions: 2,
+          },
+          onEnded: onFeedbackEnded,
+        });
       }
 
-      function onIncorrect() {
+      function onIncorrect(onFeedbackEnded: () => void) {
         PageAudioHandler.stopAndDisconnectNode();
         cycleId++;
 
@@ -148,6 +154,7 @@ export const downexStimulus = (
             enabled: true,
             maxRepetitions: 2,
           },
+          onEnded: onFeedbackEnded,
         };
 
         PageAudioHandler.playAudio(mediaAssets.audio.matrixReasoningFeedbackIncorrectDownex, audioConfig);

--- a/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
+++ b/task-launcher/src/tasks/matrix-reasoning/trials/instructions.ts
@@ -421,14 +421,20 @@ export const downexInstructions3 = {
       targetButton = buttons[targetImageIdx];
     }
 
-    function onCorrect() {
+    function onCorrect(onFeedbackEnded: () => void) {
       PageAudioHandler.stopAndDisconnectNode();
       cycleId++;
 
-      PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne);
+      PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne, {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+        onEnded: onFeedbackEnded,
+      });
     }
 
-    function onIncorrect() {
+    function onIncorrect(onFeedbackEnded: () => void) {
       PageAudioHandler.stopAndDisconnectNode();
       cycleId++;
 
@@ -438,7 +444,13 @@ export const downexInstructions3 = {
         targetButton.style.animation = 'pulse 2s 0s 2';
       }
 
-      PageAudioHandler.playAudio(mediaAssets.audio.matrixReasoningFeedbackIncorrectDownex);
+      PageAudioHandler.playAudio(mediaAssets.audio.matrixReasoningFeedbackIncorrectDownex, {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+        onEnded: onFeedbackEnded,
+      });
     }
 
     addPracticeButtonListeners(downexData3.choices[1], isTouchScreen, downexData3.choices, onCorrect, onIncorrect);
@@ -586,14 +598,20 @@ export const downexInstructions4 = {
       targetButton = buttons[targetImageIdx];
     }
 
-    function onCorrect() {
+    function onCorrect(onFeedbackEnded: () => void) {
       PageAudioHandler.stopAndDisconnectNode();
       cycleId++;
 
-      PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne);
+      PageAudioHandler.playAudio(mediaAssets.audio.feedbackRightOne, {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+        onEnded: onFeedbackEnded,
+      });
     }
 
-    function onIncorrect() {
+    function onIncorrect(onFeedbackEnded: () => void) {
       PageAudioHandler.stopAndDisconnectNode();
       cycleId++;
 
@@ -603,7 +621,13 @@ export const downexInstructions4 = {
         targetButton.style.animation = 'pulse 2s 0s 2';
       }
 
-      PageAudioHandler.playAudio(mediaAssets.audio.matrixReasoningFeedbackSmBlueDownex);
+      PageAudioHandler.playAudio(mediaAssets.audio.matrixReasoningFeedbackSmBlueDownex, {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+        onEnded: onFeedbackEnded,
+      });
     }
 
     addPracticeButtonListeners(downexData4.choices[2], isTouchScreen, downexData4.choices, onCorrect, onIncorrect);

--- a/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
+++ b/task-launcher/src/tasks/shared/helpers/handlePracticeButtons.ts
@@ -3,19 +3,38 @@ import { taskStore } from '../../../taskStore';
 import { jsPsych } from '../../taskSetup';
 import { PageAudioHandler } from './audioHandler';
 
+type PracticeFeedbackCallback = (onFeedbackEnded: () => void) => void;
+
+let isFeedbackPlaying = false;
+
 function enableBtns(btnElements: NodeListOf<HTMLButtonElement>) {
   btnElements.forEach((btn) => {
     btn.disabled = false;
   });
 }
 
+function disableBtns(btnElements: NodeListOf<HTMLButtonElement>) {
+  btnElements.forEach((btn) => {
+    btn.disabled = true;
+  });
+}
+
+function clearAudioOnEndedBeforeStop() {
+  // Clear onended before stop so an interrupted clip cannot unlock early
+  if (PageAudioHandler.audioSource) {
+    PageAudioHandler.audioSource.onended = null;
+  }
+  PageAudioHandler.stopAndDisconnectNode();
+}
+
 export function addPracticeButtonListeners(
   answer: string,
   isTouchScreen: boolean,
   choices: string[],
-  onCorrect?: () => void,
-  onIncorrect?: () => void,
+  onCorrect?: PracticeFeedbackCallback,
+  onIncorrect?: PracticeFeedbackCallback,
 ) {
+  isFeedbackPlaying = false;
   const practiceBtns: NodeListOf<HTMLButtonElement> = document.querySelectorAll('.practice-btn');
 
   practiceBtns.forEach((btn, i) => {
@@ -33,19 +52,19 @@ function handlePracticeButtonPress(
   practiceBtns: NodeListOf<HTMLButtonElement>,
   responsevalue: string | number,
   choices: string[],
-  onCorrect?: () => void,
-  onIncorrect?: () => void,
+  onCorrect?: PracticeFeedbackCallback,
+  onIncorrect?: PracticeFeedbackCallback,
 ) {
+  if (isFeedbackPlaying) {
+    return;
+  }
+
+  isFeedbackPlaying = true;
+  disableBtns(practiceBtns);
+
   const index = Array.prototype.indexOf.call(practiceBtns, btn);
   const choice = choices[index];
   const isCorrectChoice = choice?.toString() === answer;
-
-  const audioConfig: AudioConfigType = {
-    restrictRepetition: {
-      enabled: false,
-      maxRepetitions: 2,
-    },
-  };
 
   // custom incorrect prompts by task
   const incorrectPromptKey =
@@ -57,30 +76,59 @@ function handlePracticeButtonPress(
 
   if (isCorrectChoice) {
     btn.classList.add('success-shadow');
+
+    function finishTrial() {
+      isFeedbackPlaying = false;
+      jsPsych.finishTrial({
+        response: choice,
+        incorrectPracticeResponses: taskStore().incorrectPracticeResponses,
+        button_response: responsevalue,
+      });
+    }
+
     setTimeout(
-      () =>
-        jsPsych.finishTrial({
-          response: choice,
-          incorrectPracticeResponses: taskStore().incorrectPracticeResponses,
-          button_response: responsevalue,
-        }),
+      finishTrial,
       onCorrect ? 3000 : 1000, // if callback is provided, give more time for callback to finish before ending trial
     );
 
     // if there is audio playing, stop it first before playing feedback audio to prevent overlap between trials
-    PageAudioHandler.stopAndDisconnectNode();
-    onCorrect ? onCorrect() : PageAudioHandler.playAudio(mediaAssets.audio.feedbackGoodJob, audioConfig);
+    clearAudioOnEndedBeforeStop();
+    if (onCorrect) {
+      onCorrect(() => {
+        // Trial finish is still driven by the existing timeout so correct timing is preserved.
+      });
+    } else {
+      PageAudioHandler.playAudio(mediaAssets.audio.feedbackGoodJob, {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+      });
+    }
   } else {
     btn.classList.add('error-shadow');
-    // jspysch disables the buttons for some reason, so re-enable them
-    setTimeout(() => enableBtns(practiceBtns), 500);
 
     const incorrectPracticeResponses = taskStore().incorrectPracticeResponses;
     incorrectPracticeResponses.push(choice);
     taskStore('incorrectPracticeResponses', incorrectPracticeResponses);
 
-    PageAudioHandler.stopAndDisconnectNode();
+    function unlockPracticeButtons() {
+      isFeedbackPlaying = false;
+      enableBtns(practiceBtns);
+    }
 
-    onIncorrect ? onIncorrect() : PageAudioHandler.playAudio(mediaAssets.audio[incorrectPromptKey], audioConfig);
+    clearAudioOnEndedBeforeStop();
+
+    if (onIncorrect) {
+      onIncorrect(unlockPracticeButtons);
+    } else {
+      PageAudioHandler.playAudio(mediaAssets.audio[incorrectPromptKey], {
+        restrictRepetition: {
+          enabled: false,
+          maxRepetitions: 2,
+        },
+        onEnded: unlockPracticeButtons,
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR adds changes that guard against button mashing in practice trials, which had prevented the task from advancing to the next trial. Practice buttons are now disabled until the feedback audio from an already-selected button is done playing. It also disables the hover property on touch screens, which prevents the buttons from appearing selected unexpectedly. 