### PR TITLE
Fix sds matching trials and missing final response

### DIFF
--- a/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
+++ b/task-launcher/src/tasks/same-different-selection/trials/afcMatch.ts
@@ -430,7 +430,9 @@ export const afcMatch = (trial?: StimulusType) => {
           return trial.trialNumber === stim.trialNumber && trial.trialType === stim.trialType;
         });
 
-        selectNextSequentialTrial(nextTrials);
+        if (stim.assessmentStage !== 'practice_response') {
+          selectNextSequentialTrial(nextTrials);
+        }
       }
     },
   };

--- a/task-launcher/src/tasks/shared/helpers/appTimer.ts
+++ b/task-launcher/src/tasks/shared/helpers/appTimer.ts
@@ -44,7 +44,8 @@ export const startAppTimer = (maxTimeInMinutes: number) => {
 };
 
 // function for ending the task if the next trial
-export async function checkEndTaskEarly(timeRemaining: number, stimAudio: string) {
+// returns true if the experiment was ended early, false otherwise
+export async function checkEndTaskEarly(timeRemaining: number, stimAudio: string): Promise<boolean> {
   const pageStateHandler = new PageStateHandler(stimAudio, false);
   let minTrialDuration = (await pageStateHandler.getStimulusDurationMs()) + RESPONSE_BUFFER;
 
@@ -55,5 +56,8 @@ export async function checkEndTaskEarly(timeRemaining: number, stimAudio: string
   if (timeRemaining < minTrialDuration) {
     clearTimeout(taskStore().taskTimer);
     finishExperiment();
+    return true;
   }
+
+  return false;
 }

--- a/task-launcher/src/tasks/shared/helpers/getStimulus.ts
+++ b/task-launcher/src/tasks/shared/helpers/getStimulus.ts
@@ -59,7 +59,18 @@ export const getStimulus = (corpusType: string, blockNumber?: number, storyGroup
   const timeElapsed = getActiveTaskElapsedMs();
   const timeRemaining = maxTimeInMilliseconds - timeElapsed;
 
-  checkEndTaskEarly(timeRemaining, stimAudio);
+  // pause the experiment while we asynchronously check whether there is enough
+  // time for the next trial, so a live trial can't start (and be aborted) mid-check
+  jsPsych.pauseExperiment();
+  void checkEndTaskEarly(timeRemaining, stimAudio)
+    .then(() => {
+      jsPsych.resumeExperiment();
+    })
+    .catch((error) => {
+      // fail open so a buffer-load error can't leave the task paused forever
+      console.error('checkEndTaskEarly failed:', error);
+      jsPsych.resumeExperiment();
+    });
 
   // store the item for use in the trial
   taskStore('nextStimulus', itemSuggestion.nextStimulus);


### PR DESCRIPTION
This PR fixes two bugs:

- The first matching trial was displaying 2 `first_response` trials in a row, instead of one `first_response` and the corresponding `second_response`
- There was a race condition causing the async function `checkEndTaskEarly` to finish the task in the middle of a trial, which would add an extra trial to the data with `response: {}` and `correct: FALSE` that the user never saw. The task now waits for this function to return before continuing.