### PR TITLE
Use the same string keys for both audio and text in feedback trials

### DIFF
--- a/task-launcher/src/tasks/math/timeline.ts
+++ b/task-launcher/src/tasks/math/timeline.ts
@@ -94,7 +94,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
 
   const feedbackBlock = (trial?: StimulusType) => {
     return {
-      timeline: [feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight', false)],
+      timeline: [feedback(true)],
       conditional_function: () => {
         return (
           (trial || taskStore().nextStimulus).assessmentStage === 'practice_response' &&
@@ -166,7 +166,7 @@ export default function buildMathTimeline(config: Record<string, any>, mediaAsse
       trials.push(slider(layoutConfigMap, terminateCat, trial));
       if (index < sliderPractice.length - 1) {
         trials.push({
-          ...feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight'),
+          ...feedback(true),
           conditional_function: () => {
             return true;
           },

--- a/task-launcher/src/tasks/memory-game/timeline.ts
+++ b/task-launcher/src/tasks/memory-game/timeline.ts
@@ -18,7 +18,7 @@ const generatePracticeTrialTimeline = (reverse: boolean, tryAgainText: string, r
   const basicBlock = [
     getCorsiBlocks({ mode: 'display', isPractice: true, reverse }),
     getCorsiBlocks({ mode: 'input', isPractice: true, reverse }),
-    feedback(true, 'feedbackCorrect', tryAgainText, true),
+    feedback(true, tryAgainText),
   ];
 
   const finalTimeline = [];
@@ -35,7 +35,7 @@ const getSecondRoundPracticeTrials = (reverse: boolean, tryAgainText: string) =>
       getCorsiBlocks({ mode: 'display', isPractice: true, reverse }),
       getCorsiBlocks({ mode: 'input', isPractice: true, reverse }),
       {
-        timeline: [feedback(true, 'feedbackCorrect', tryAgainText, true)],
+        timeline: [feedback(true, tryAgainText)],
         conditional_function: () => {
           return taskStore().isCorrect;
         },
@@ -55,11 +55,11 @@ export default function buildMemoryTimeline(config: Record<string, any>) {
   const initialTimeline = initTimeline(config, enterFullscreen);
 
   const corsiBlocksPractice = {
-    timeline: [...generatePracticeTrialTimeline(false, 'memoryGameForwardTryAgain', 3)],
+    timeline: [...generatePracticeTrialTimeline(false, 'memoryGameInput', 3)],
   };
 
   const corsiBlocksPracticeReverse = {
-    timeline: [...generatePracticeTrialTimeline(true, 'memoryGameBackwardTryAgain', 3)],
+    timeline: [...generatePracticeTrialTimeline(true, 'memoryGameBackwardPrompt', 3)],
   };
 
   const forwardTrial = () => {
@@ -97,7 +97,7 @@ export default function buildMemoryTimeline(config: Record<string, any>) {
   taskStore('totalTestTrials', totalRealTrials);
 
   const downexFeedbackCorrect = {
-    timeline: [feedback(true, 'feedbackCorrect', 'memoryGameForwardTryAgain', true)],
+    timeline: [feedback(true)],
     conditional_function: () => {
       return taskStore().isCorrect;
     },
@@ -168,7 +168,7 @@ export default function buildMemoryTimeline(config: Record<string, any>) {
     timeline: [
       reverseOrderPrompt,
       corsiBlocksPracticeReverse,
-      getSecondRoundPracticeTrials(true, 'memoryGameBackwardTryAgain'),
+      getSecondRoundPracticeTrials(true, 'memoryGameBackwardPrompt'),
     ],
   };
 
@@ -176,7 +176,7 @@ export default function buildMemoryTimeline(config: Record<string, any>) {
     timeline: [
       ...defaultInstructions,
       corsiBlocksPractice,
-      getSecondRoundPracticeTrials(false, 'memoryGameForwardTryAgain'),
+      getSecondRoundPracticeTrials(false, 'memoryGameInput'),
       readyToPlay,
     ],
   };

--- a/task-launcher/src/tasks/same-different-selection/catTimeline.ts
+++ b/task-launcher/src/tasks/same-different-selection/catTimeline.ts
@@ -81,7 +81,7 @@ export default function buildSameDifferentTimelineCat(config: Record<string, any
   };
 
   const feedbackBlock = {
-    timeline: [feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight')],
+    timeline: [feedback(true)],
     conditional_function: () => {
       return taskStore().version === 2;
     },

--- a/task-launcher/src/tasks/same-different-selection/timeline.ts
+++ b/task-launcher/src/tasks/same-different-selection/timeline.ts
@@ -67,7 +67,7 @@ export default function buildSameDifferentTimeline(config: Record<string, any>, 
   };
 
   const feedbackBlock = {
-    timeline: [feedback(true, 'feedbackCorrect', 'feedbackNotQuiteRight')],
+    timeline: [feedback(true)],
     conditional_function: () => {
       return (
         taskStore().nextStimulus.assessmentStage === 'practice_response' &&

--- a/task-launcher/src/tasks/shared/trials/feedback.ts
+++ b/task-launcher/src/tasks/shared/trials/feedback.ts
@@ -55,7 +55,9 @@ export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
             },
             onEnded: () => {
               if (!trialFinished && promptOnIncorrect && !isCorrect) {
-                PageAudioHandler.playAudio(mediaAssets.audio[promptOnIncorrect] || mediaAssets.audio.nullAudio);
+                PageAudioHandler.playAudio(
+                  mediaAssets.audio[camelize(promptOnIncorrect)] || mediaAssets.audio.nullAudio,
+                );
               }
             },
           };

--- a/task-launcher/src/tasks/shared/trials/feedback.ts
+++ b/task-launcher/src/tasks/shared/trials/feedback.ts
@@ -1,15 +1,10 @@
 import jsPsychHtmlMultiResponse from '@jspsych-contrib/plugin-html-multi-response';
 import { mediaAssets } from '../../..';
 import { taskStore } from '../../../taskStore';
-import { PageAudioHandler } from '../helpers';
+import { camelize, PageAudioHandler } from '../helpers';
 
 // isPractice parameter is for tasks that don't have a corpus (e.g. memory game)
-export const feedback = (
-  isPractice = false,
-  correctFeedbackAudioKey: string,
-  inCorrectFeedbackAudioKey: string,
-  showPrompt: boolean = false,
-) => {
+export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
   return {
     timeline: [
       {
@@ -18,25 +13,6 @@ export const feedback = (
           const t = taskStore().translations;
           const isCorrect = taskStore().isCorrect;
           const imageUrl = isCorrect ? mediaAssets.images['smilingFace@2x'] : mediaAssets.images['sadFace@2x'];
-          let promptOnIncorrect: string; // prompt displayed at bottom if incorrect, differs by task
-
-          switch (taskStore().task) {
-            case 'same-different-selection':
-              promptOnIncorrect = t.sds2matchPrompt1;
-              break;
-            case 'memory-game':
-              if (inCorrectFeedbackAudioKey.toUpperCase().includes('BACKWARD')) {
-                promptOnIncorrect = t.memoryGameBackwardPrompt;
-              } else {
-                promptOnIncorrect = t.memoryGameInput;
-              }
-              break;
-            case 'egma-math':
-              promptOnIncorrect = t.numberLineSliderPrompt1;
-              break;
-            default:
-              promptOnIncorrect = '';
-          }
 
           return `<div class="lev-stimulus-container">
                             <div class="lev-row-container instruction">
@@ -47,10 +23,10 @@ export const feedback = (
                             </div>
                     
                             ${
-                              isCorrect || !showPrompt
+                              isCorrect || !promptOnIncorrect
                                 ? ''
                                 : `<div class="lev-row-container instruction"'>
-                                <p>${promptOnIncorrect}</p>
+                                <p>${taskStore().translations[camelize(promptOnIncorrect)]}</p>
                               </div>`
                             }
                         </div>`;
@@ -64,19 +40,22 @@ export const feedback = (
         },
         on_load: () => {
           const isCorrect = taskStore().isCorrect;
-          const stimulusPath = isCorrect
-            ? mediaAssets.audio[correctFeedbackAudioKey]
-            : mediaAssets.audio[inCorrectFeedbackAudioKey];
+          const feedbackAudio = isCorrect ? mediaAssets.audio.feedbackCorrect : mediaAssets.audio.feedbackNotQuiteRight;
 
           const audioConfig: AudioConfigType = {
             restrictRepetition: {
               enabled: false,
               maxRepetitions: 2,
             },
+            onEnded: () => {
+              if (promptOnIncorrect && !isCorrect) {
+                PageAudioHandler.playAudio(mediaAssets.audio[promptOnIncorrect]);
+              }
+            },
           };
 
           PageAudioHandler.stopAndDisconnectNode();
-          PageAudioHandler.playAudio(stimulusPath || mediaAssets.audio.nullAudio, audioConfig);
+          PageAudioHandler.playAudio(feedbackAudio || mediaAssets.audio.nullAudio, audioConfig);
         },
         on_finish: () => {
           PageAudioHandler.stopAndDisconnectNode();

--- a/task-launcher/src/tasks/shared/trials/feedback.ts
+++ b/task-launcher/src/tasks/shared/trials/feedback.ts
@@ -5,6 +5,11 @@ import { camelize, PageAudioHandler } from '../helpers';
 
 // isPractice parameter is for tasks that don't have a corpus (e.g. memory game)
 export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
+  // Guards against the chained prompt audio bleeding into the next trial when
+  // the user clicks Continue before the first feedback audio finishes playing.
+  // stopAndDisconnectNode() in on_finish calls stop(), which fires onended.
+  let trialFinished = false;
+
   return {
     timeline: [
       {
@@ -39,6 +44,7 @@ export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
           return `<button class="primary">${t.continueButtonText}</button>`;
         },
         on_load: () => {
+          trialFinished = false;
           const isCorrect = taskStore().isCorrect;
           const feedbackAudio = isCorrect ? mediaAssets.audio.feedbackCorrect : mediaAssets.audio.feedbackNotQuiteRight;
 
@@ -48,8 +54,8 @@ export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
               maxRepetitions: 2,
             },
             onEnded: () => {
-              if (promptOnIncorrect && !isCorrect) {
-                PageAudioHandler.playAudio(mediaAssets.audio[promptOnIncorrect]);
+              if (!trialFinished && promptOnIncorrect && !isCorrect) {
+                PageAudioHandler.playAudio(mediaAssets.audio[promptOnIncorrect] || mediaAssets.audio.nullAudio);
               }
             },
           };
@@ -58,6 +64,7 @@ export const feedback = (isPractice = false, promptOnIncorrect?: string) => {
           PageAudioHandler.playAudio(feedbackAudio || mediaAssets.audio.nullAudio, audioConfig);
         },
         on_finish: () => {
+          trialFinished = true;
           PageAudioHandler.stopAndDisconnectNode();
         },
       },


### PR DESCRIPTION
In memory game feedback trials, the top and bottom text was coming from two different string keys (for example in incorrect trials: `feedback-not-quite-right` and `memory-game-input`) but the audio was `memoryGameTryAgain`, which is a combination of the text in the separate individual text keys. This PR plays two separate audio files in the feedback trials to match the text keys used. 