### PR TITLE
fix: race on audio context resume

### DIFF
--- a/task-launcher/src/tasks/shared/helpers/audioHandler.ts
+++ b/task-launcher/src/tasks/shared/helpers/audioHandler.ts
@@ -89,20 +89,4 @@ export class PageAudioHandler {
       return;
     }
   }
-
-  // required on iOS to prevent autoplay blocking
-  static unlockAudioContext() {
-    const ctx = jsPsych.pluginAPI.audioContext();
-
-    // safari requires resuming audio context on user interaction, then it can be used freely later
-    if (ctx.state === 'suspended') {
-      ctx.resume();
-    }
-
-    const buffer = ctx.createBuffer(1, 1, ctx.sampleRate);
-    const source = ctx.createBufferSource();
-    source.buffer = buffer;
-    source.connect(ctx.destination);
-    source.start(0);
-  }
 }

--- a/task-launcher/src/tasks/shared/trials/fullScreen.ts
+++ b/task-launcher/src/tasks/shared/trials/fullScreen.ts
@@ -1,58 +1,69 @@
 import jsPsychFullScreen from '@jspsych/plugin-fullscreen';
+import jsPsychHtmlMultiResponse from '@jspsych-contrib/plugin-html-multi-response';
 import fscreen from 'fscreen';
 import { taskStore } from '../../../taskStore';
 import { setupInputDetection } from '../../../utils/detectInput';
-import { isTouchScreen } from '../../taskSetup';
-import { PageAudioHandler } from '../helpers/audioHandler';
+import { jsPsych } from '../../taskSetup';
 
 export const enterFullscreen = {
-  type: jsPsychFullScreen,
-  // force fullscreen on a touchscreen so that audio context can be unlocked
-  fullscreen_mode: !!fscreen.fullscreenEnabled || isTouchScreen,
-  message: () => {
+  type: jsPsychHtmlMultiResponse,
+  stimulus: () => {
     const t = taskStore().translations;
     return `<div class="lev-row-container header">
         <p>${t.generalFullscreen}</p>
       </div>
       `;
   },
-  delay_after: 0,
-  button_label: () => `${taskStore().translations.continueButtonText}`,
+  button_choices: [''], // Must not be empty for the button_html to render
+  keyboard_choices: 'NO_KEYS',
+  button_html: () => `<button class="primary">${taskStore().translations.continueButtonText}</button>`,
+  response_ends_trial: false, // Disable automatic trial advancement
   on_load: () => {
-    const continueButton = document.getElementById('jspsych-fullscreen-btn');
-    if (continueButton) {
-      continueButton.id = 'dummy';
-      continueButton.classList.add('primary');
-    }
+    // Capture the start time so we can report the response time (rt) below.
+    const startTime = performance.now();
 
-    if (isTouchScreen) {
-      continueButton?.addEventListener(
-        'click',
-        () => {
-          PageAudioHandler.unlockAudioContext();
-        },
-        { once: true },
-      );
-      continueButton?.addEventListener(
-        'touchend',
-        () => {
-          PageAudioHandler.unlockAudioContext();
-        },
-        { once: true },
-      );
-    }
-
+    // Detect the user's input capability.
     const inputDetector = setupInputDetection();
     taskStore('inputCapability', inputDetector.capability);
+
+    // We listen for both 'touchend' and 'click' so the button responds on the
+    // widest range of devices. On touch, the two can fire for a single tap:
+    // browsers synthesize a 'click' after 'touchend'. Modern mobile browsers do
+    // this reliably, but older ones are inconsistent, which is why we can't rely
+    // on 'click' alone and keep the 'touchend' listener too. The `handled` flag
+    // ensures the trial only advances once when both fire for the same tap.
+    const continueButton = document.querySelector<HTMLButtonElement>('#jspsych-html-multi-response-btngroup button');
+    let handled = false;
+    const handleContinue = async () => {
+      if (handled) return;
+      handled = true;
+      continueButton?.removeEventListener('click', handleContinue);
+      continueButton?.removeEventListener('touchend', handleContinue);
+
+      // Resume the audio context so the next trial's audio can autoplay, then
+      // request fullscreen.
+      // NB: browsers (notably Safari) only honor resume() when it is *called*
+      // synchronously during a user gesture. Awaiting it doesn't change that
+      // (the call still happens synchronously here) but it holds off advancing
+      // until the context is actually running, which narrows the race with the
+      // next trial's audio autoplay. The key constraint is that nothing may be
+      // awaited *before* this line: after the first await the handler
+      // continues on a later microtask, by which point the gesture's
+      // activation has expired and resume() is ignored.
+      await jsPsych.pluginAPI.audioContext().resume();
+      if (fscreen.fullscreenEnabled) {
+        fscreen.requestFullscreen(document.documentElement);
+      }
+
+      // Manually advance the trial.
+      jsPsych.finishTrial({ success: true, rt: Math.round(performance.now() - startTime) });
+    };
+    continueButton?.addEventListener('click', handleContinue);
+    continueButton?.addEventListener('touchend', handleContinue);
   },
   on_start: () => {
     document.body.style.cursor = 'default';
   },
-};
-
-export const ifNotFullscreen = {
-  timeline: [enterFullscreen],
-  conditional_function: () => fscreen.fullscreenElement === null,
 };
 
 export const exitFullscreen = {

--- a/task-launcher/src/tasks/shared/trials/fullScreen.ts
+++ b/task-launcher/src/tasks/shared/trials/fullScreen.ts
@@ -40,23 +40,25 @@ export const enterFullscreen = {
       continueButton?.removeEventListener('click', handleContinue);
       continueButton?.removeEventListener('touchend', handleContinue);
 
-      // Resume the audio context so the next trial's audio can autoplay, then
-      // request fullscreen.
-      // NB: browsers (notably Safari) only honor resume() when it is *called*
-      // synchronously during a user gesture. Awaiting it doesn't change that
-      // (the call still happens synchronously here) but it holds off advancing
-      // until the context is actually running, which narrows the race with the
-      // next trial's audio autoplay. The key constraint is that nothing may be
-      // awaited *before* this line: after the first await the handler
-      // continues on a later microtask, by which point the gesture's
-      // activation has expired and resume() is ignored.
-      await jsPsych.pluginAPI.audioContext().resume();
-      if (fscreen.fullscreenEnabled) {
-        fscreen.requestFullscreen(document.documentElement);
+      try {
+        // Resume the audio context so the next trial's audio can autoplay.
+        // NB: browsers (notably Safari) only honor resume() when it is
+        // *called* synchronously during a user gesture. Awaiting it doesn't
+        // change that (the call still happens synchronously here) but it holds
+        // off advancing until the context is actually running, which narrows
+        // the race with the next trial's audio autoplay. The key constraint is
+        // that nothing may be awaited *before* this line: after the first
+        // await the handler continues on a later microtask, by which point the
+        // gesture's activation has expired and resume() is ignored.
+        await jsPsych.pluginAPI.audioContext()?.resume();
+      } finally {
+        // Request fullscreen.
+        if (fscreen.fullscreenEnabled) {
+          fscreen.requestFullscreen(document.documentElement);
+        }
+        // Manually advance the trial.
+        jsPsych.finishTrial({ success: true, rt: Math.round(performance.now() - startTime) });
       }
-
-      // Manually advance the trial.
-      jsPsych.finishTrial({ success: true, rt: Math.round(performance.now() - startTime) });
     };
     continueButton?.addEventListener('click', handleContinue);
     continueButton?.addEventListener('touchend', handleContinue);

--- a/task-launcher/src/tasks/shared/trials/fullScreen.ts
+++ b/task-launcher/src/tasks/shared/trials/fullScreen.ts
@@ -34,7 +34,14 @@ export const enterFullscreen = {
     // ensures the trial only advances once when both fire for the same tap.
     const continueButton = document.querySelector<HTMLButtonElement>('#jspsych-html-multi-response-btngroup button');
     let handled = false;
-    const handleContinue = async () => {
+    const handleContinue = async (event: Event) => {
+      // We manage advancement ourselves (finishTrial below), so stop the event
+      // from reaching the html-multi-response plugin's own button handler, which
+      // would otherwise run against the DOM we've just torn down and throw.
+      // preventDefault on touchend also suppresses the synthesized ghost click.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
       if (handled) return;
       handled = true;
       continueButton?.removeEventListener('click', handleContinue);


### PR DESCRIPTION
For widest browser support, AudioContext `resume()` must only called synchronously within a user gesture handler. This was satisfied via handlers on `click` and `touchend` in the `enterFullscreen` trial.

However, `enterFullscreen` used `@jspsych/plugin-fullscreen` which set its own `click` handler on the same button element that would execute first, creating a race between `resume()` and subsequent audio autoplay. This would sometimes cause the first audio on the next trial to not play, which forced the user to replay it w/ the speaker button in order to advance.

I switched this trial to use `@jspsych-contrib/plugin-html-multi-response` in order to have control over when the trial advances in order to ensure `resume()` is called correctly and finishes before any audio plays in subsequent trials.

Deleted `ifNotFullscreen` trial - it was unused and would cause `resume()` to not get called if the user was already in fullscreen when starting the experiment.

Deleted the 1-frame silent buffer trick - webkit properly supported `resume()` ~2016 so no longer necessary.