### PR TITLE
fix: flower practice replay audio + prevent image dragging

### DIFF
--- a/task-launcher/src/styles/components/_buttons.scss
+++ b/task-launcher/src/styles/components/_buttons.scss
@@ -1,6 +1,13 @@
 @use '../abstracts' as *;
 
 button {
+  img {
+    -webkit-user-drag: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   &.button-base {
     border-radius: $button-default-border-radius;
     border-width: $button-default-border-width;

--- a/task-launcher/src/styles/layout/_containers.scss
+++ b/task-launcher/src/styles/layout/_containers.scss
@@ -165,6 +165,10 @@
     max-width: 100%;
     width: calc(3 * $response-size-default);
     height: calc(3 * $response-size-default);
+    -webkit-user-drag: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
   }
 }
 

--- a/task-launcher/src/tasks/hearts-and-flowers/timeline.js
+++ b/task-launcher/src/tasks/hearts-and-flowers/timeline.js
@@ -187,14 +187,14 @@ function getHeartOrFlowerInstructionsSection(_adminConfig, stimulusType) {
     instructionPracticePromptText1,
     instructionPracticePromptAudio1,
     instructionPracticeStimulusSide1,
-    'heartInstruct2',
+    stimulusType === StimulusType.Heart ? 'heartInstruct2' : 'flowerInstruct2',
   );
   const instructionPractice2 = buildInstructionPracticeTrial(
     stimulusType,
     instructionPracticePromptText2,
     instructionPracticePromptAudio2,
     instructionPracticeStimulusSide2,
-    'heartPracticeFeedback1',
+    stimulusType === StimulusType.Heart ? 'heartPracticeFeedback1' : 'flowerPracticeFeedback1',
   );
 
   // Now let's build our timeline. Notice how we are pairing each practice trials with a feedback trial


### PR DESCRIPTION
Fixes freshdesk ticket https://levante-support.freshdesk.com/a/tickets/106. I wasn't able to replicate the problem described in this ticket: https://levante-support.freshdesk.com/a/tickets/105, but I disabled user dragging and touch callout, which will prevent images from being draggable and hopefully fix the issue mentioned in the ticket.