### PR TITLE
fix: host-aware Sentry init for embedded and standalone tasks

### DIFF
--- a/task-launcher/serve/serve.js
+++ b/task-launcher/serve/serve.js
@@ -1,29 +1,15 @@
-import * as Sentry from '@sentry/browser';
 import i18next from 'i18next';
 import { TaskLauncher } from '../src';
+import { initSentry } from '../src/sentry.js';
 import { stringToBoolean } from '../src/tasks/shared/helpers/stringToBoolean';
 
 // Import necessary in order to use async/await at the top level
 import 'regenerator-runtime/runtime';
 
 /**
- * Initialize Sentry first!
+ * Initialize Sentry first (no-op if a host client already exists).
  */
-Sentry.init({
-  dsn: 'https://9d67b24a405feffb49477ca8002cc033@o4507250485035008.ingest.us.sentry.io/4507376476618752',
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
-  // Performance Monitoring
-  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-
-  // TODO spyne Remove this. For testing sentry. Use this to enable localhost monitoring
-  // tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
-  tracePropagationTargets: ['https://hs-levante-admin-dev.web.app'],
-
-  // Session Replay
-  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-});
+initSentry();
 
 // TODO: Add game params for all tasks
 const queryString = new URL(window.location).search;

--- a/task-launcher/src/index.ts
+++ b/task-launcher/src/index.ts
@@ -10,6 +10,8 @@ import {
 } from './tasks/shared/helpers';
 import './styles/index.scss';
 import type { RoarAppkit } from '@levante-framework/firekit';
+// @ts-expect-error: keep sentry as .js for the function-based browser API
+import { initSentry } from './sentry.js';
 import { setTaskStore, taskStore } from './taskStore';
 import { getBucketName } from './tasks/shared/helpers/getBucketName';
 import taskConfig from './tasks/taskConfig';
@@ -39,6 +41,8 @@ export class TaskLauncher {
   }
 
   async init() {
+    initSentry();
+
     if (!this.gameParams.demoMode && this.firekit) {
       await this.firekit.startRun();
     }

--- a/task-launcher/src/sentry.js
+++ b/task-launcher/src/sentry.js
@@ -1,0 +1,33 @@
+import { browserTracingIntegration, getClient, init, replayIntegration } from '@sentry/browser';
+
+// Default key for levante-framework/core-tasks
+const CORE_TASKS_DSN =
+  'https://9d67b24a405feffb49477ca8002cc033@o4507250485035008.ingest.us.sentry.io/4507376476618752';
+
+const regexLevantePreview = /^https:\/\/hs-levante-admin-(prod|dev)(--pr\d+-\w+)?\.web\.app/;
+
+/**
+ * Initialize Sentry for standalone task hosts.
+ * When embedded in the dashboard (or any host that already called Sentry.init),
+ * skip so we do not clobber the parent client.
+ */
+export function initSentry() {
+  if (getClient()) {
+    return;
+  }
+
+  init({
+    dsn: CORE_TASKS_DSN,
+    integrations: [browserTracingIntegration(), replayIntegration()],
+    tracesSampleRate: 1.0,
+    tracePropagationTargets: [
+      regexLevantePreview,
+      'https://platform.levante-network.org',
+      'https://hs-levante-admin-prod.web.app',
+      'https://hs-levante-admin-dev.web.app',
+      'localhost',
+    ],
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+}

--- a/task-launcher/src/tasks/shared/helpers/setSentryContext.ts
+++ b/task-launcher/src/tasks/shared/helpers/setSentryContext.ts
@@ -6,5 +6,5 @@ export type SentryContextType = {
 };
 
 export const setSentryContext = (context: SentryContextType) => {
-  Sentry.setContext('LevanteContext', context);
+  Sentry.setContext('TaskContext', context);
 };


### PR DESCRIPTION
EARLY DRAFT ONLY NOT FOR REVIEW

## Summary
- Centralize Sentry init in `task-launcher/src/sentry.js` against the live `levante-framework/core-tasks` DSN
- Skip re-init when a host (dashboard) already owns the Sentry client
- Expand standalone trace targets to prod/platform hosts; rename context to `TaskContext`

## Test plan
- [ ] Embedded: load a task in dashboard; confirm a single Sentry client (dashboard DSN) remains
- [ ] Standalone `serve`: confirm events can land in the `core-tasks` Sentry project
- [ ] Confirm trial `TaskContext` still attaches on task errors